### PR TITLE
Make date divider color independent from received message text color

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -27,6 +27,7 @@ abstract class ChatTheme {
     required this.sendButtonIcon,
     required this.subtitle1,
     required this.subtitle2,
+    required this.subtitle2Color,
   });
 
   /// Icon for select attachment button
@@ -91,6 +92,9 @@ abstract class ChatTheme {
 
   /// Subtitle, used for date dividers in the chat
   final TextStyle subtitle2;
+
+  /// Color of subtitle, used for date dividers in the chat
+  final Color subtitle2Color;
 }
 
 /// Default chat theme which extends [ChatTheme]
@@ -148,6 +152,7 @@ class DefaultChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
+    Color subtitle2Color = const Color(0xff1d1d21),
   }) : super(
           attachmentButtonIcon: attachmentButtonIcon,
           backgroundColor: backgroundColor,
@@ -170,6 +175,7 @@ class DefaultChatTheme extends ChatTheme {
           sendButtonIcon: sendButtonIcon,
           subtitle1: subtitle1,
           subtitle2: subtitle2,
+          subtitle2Color: subtitle2Color,
         );
 }
 
@@ -228,6 +234,7 @@ class DarkChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
+    Color subtitle2Color = const Color(0xffffffff),
   }) : super(
           attachmentButtonIcon: attachmentButtonIcon,
           backgroundColor: backgroundColor,
@@ -250,5 +257,6 @@ class DarkChatTheme extends ChatTheme {
           sendButtonIcon: sendButtonIcon,
           subtitle1: subtitle1,
           subtitle2: subtitle2,
+          subtitle2Color: subtitle2Color,
         );
 }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -294,8 +294,8 @@ class _ChatState extends State<Chat> {
                                               ),
                                               style: widget.theme.subtitle2
                                                   .copyWith(
-                                                color: widget
-                                                    .theme.secondaryTextColor,
+                                                color:
+                                                    widget.theme.subtitle2Color,
                                               ),
                                             ),
                                           ),


### PR DESCRIPTION
When the background is light but message bubbles are dark, it's hard to find one text color that works both for received messages and for date dividers. Yet, the same `secondaryTextColor` theme property is used for both. So since the style of date dividers is defined by `subtitle2`, and to stick with the same logic as for `caption`/`captionColor`...

Added a subtitle2Color theme parameter so that the text color of date dividers can be independent from the text color of received message (`secondaryTextColor`). I set the default value of that setting to be the same as `secondaryTextColor` to keep some backward compatibility.

It might make sense to also add one for `subtitle1` but I didn't find any use of this and I wanted to minimize my changes.