### PR TITLE
Make preview url loading optional

### DIFF
--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -139,7 +139,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
 ## Link preview
 
-Link preview works automatically, we created a separate package for that, you can found it [here](https://pub.dev/packages/flutter_link_previewer). Usually, however, you'll want to save the preview data so it stays the same, you can do that using `onPreviewDataFetched` callback:
+Link preview works automatically, we created a separate package for that, you can found it [here](https://pub.dev/packages/flutter_link_previewer). If you want, it can be disabled by setting `usePreviewData` to false. Usually, however, you'll want to save the preview data so it stays the same, you can do that using `onPreviewDataFetched` callback:
 
 ```dart
 class _MyHomePageState extends State<MyHomePage> {

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -75,7 +75,7 @@ class Chat extends StatefulWidget {
   /// See [InheritedUser.user]
   final types.User user;
 
-  ///
+  /// Should Preview be calculated
   final bool usePreviewData;
 
   @override
@@ -332,6 +332,7 @@ class _ChatState extends State<Chat> {
                                             widget.onMessageTap
                                                 ?.call(tappedMessage);
                                           },
+                                          usePreviewData: widget.usePreviewData,
                                           onPreviewDataFetched:
                                               _onPreviewDataFetched,
                                           previousMessageSameAuthor:

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -31,6 +31,7 @@ class Chat extends StatefulWidget {
     required this.onSendPressed,
     this.theme = const DefaultChatTheme(),
     required this.user,
+    this.usePreviewData = true,
   }) : super(key: key);
 
   /// See [Message.dateLocale]
@@ -73,6 +74,9 @@ class Chat extends StatefulWidget {
 
   /// See [InheritedUser.user]
   final types.User user;
+
+  ///
+  final bool usePreviewData;
 
   @override
   _ChatState createState() => _ChatState();

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -19,6 +19,7 @@ class Message extends StatelessWidget {
     required this.messageWidth,
     this.onMessageLongPress,
     this.onMessageTap,
+    this.usePreviewData = true,
     this.onPreviewDataFetched,
     required this.previousMessageSameAuthor,
     required this.shouldRenderTime,
@@ -40,6 +41,9 @@ class Message extends StatelessWidget {
 
   /// Called when user taps on any message
   final void Function(types.Message)? onMessageTap;
+
+  /// Should Preview be calculated
+  final bool usePreviewData;
 
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -71,6 +75,7 @@ class Message extends StatelessWidget {
         final textMessage = message as types.TextMessage;
         return TextMessage(
           message: textMessage,
+          usePreviewData: usePreviewData,
           onPreviewDataFetched: onPreviewDataFetched,
         );
       default:

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -11,6 +11,7 @@ class TextMessage extends StatelessWidget {
   const TextMessage({
     Key? key,
     required this.message,
+    this.usePreviewData = true,
     this.onPreviewDataFetched,
   }) : super(key: key);
 
@@ -20,6 +21,9 @@ class TextMessage extends StatelessWidget {
   /// See [LinkPreview.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
+
+  /// Should Preview be calculated
+  final bool usePreviewData;
 
   void _onPreviewDataFetched(types.PreviewData previewData) {
     if (message.previewData == null) {
@@ -82,7 +86,7 @@ class TextMessage extends StatelessWidget {
     final urlRegexp = RegExp(REGEX_LINK);
     final matches = urlRegexp.allMatches(message.text.toLowerCase());
 
-    if (matches.isNotEmpty) return _linkPreview(_user, _width, context);
+    if (matches.isNotEmpty && usePreviewData) return _linkPreview(_user, _width, context);
 
     return Container(
       margin: const EdgeInsets.symmetric(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -86,8 +86,9 @@ class TextMessage extends StatelessWidget {
     final urlRegexp = RegExp(REGEX_LINK);
     final matches = urlRegexp.allMatches(message.text.toLowerCase());
 
-    if (matches.isNotEmpty && usePreviewData)
+    if (matches.isNotEmpty && usePreviewData) {
       return _linkPreview(_user, _width, context);
+    }
 
     return Container(
       margin: const EdgeInsets.symmetric(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -86,7 +86,8 @@ class TextMessage extends StatelessWidget {
     final urlRegexp = RegExp(REGEX_LINK);
     final matches = urlRegexp.allMatches(message.text.toLowerCase());
 
-    if (matches.isNotEmpty && usePreviewData) return _linkPreview(_user, _width, context);
+    if (matches.isNotEmpty && usePreviewData)
+      return _linkPreview(_user, _width, context);
 
     return Container(
       margin: const EdgeInsets.symmetric(


### PR DESCRIPTION
The link preview is always on, which can be a security issue for encrypted chats, as the links will be always loaded.
I added the functionality so it can be disabled and added a sentence in the docs.

Also the regex for the link matching matches to bad urls, e.g.  ... or a... or ...x or ._.. etc. (Any use of ellipses or some morse-code will produce a url.) 
Maybe check: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url