### PR TITLE
Text is now selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.2
+- The text inside text messages is now selectable
+
 ## 1.1.1
 
 Export `ChatList` class

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -104,7 +104,7 @@ class TextMessage extends StatelessWidget {
                   .copyWith(color: color),
             ),
           ),
-        Text(
+        SelectableText(
           message.text,
           style: user.id == message.author.id
               ? InheritedChatTheme.of(context).theme.sentMessageBodyTextStyle

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_chat_ui
 description: >
   Actively maintained, community-driven chat UI implementation with an
   optional Firebase BaaS.
-version: 1.1.1
+version: 1.1.2
 homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_ui
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

This is ready to be merged

### What does it do?

`Text` widget is now `SelectableText` for text messages

### Why is it needed?

A user may want to copy a piece of information from the chat to use on another app, for example, a phone number.
`SelectableText` makes that process easier

### How to test it?

Long press the text in a text messages

### Related issues/PRs

Unrelated issue
