### PR TITLE
Made the full composition area trigger input focus (not just the inner field).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 1.1.3
+
+Minor change to make it easier to focus the input field by making the entire composition area tappable.
+
 ## 1.1.2
+
 - The text inside text messages is now selectable
 
 ## 1.1.1
@@ -7,7 +12,7 @@ Export `ChatList` class
 
 ## 1.1.0
 
-This release markes a major chat architecture overhaul based on a community feedback. In the future we don't expect such big changes in one release and will try to do backwards compatible code as much as possible.
+This release marks a major chat architecture overhaul based on a community feedback. In the future we don't expect such big changes in one release and will try to do backwards compatible code as much as possible.
 
 Breaking changes:
 

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -37,15 +37,18 @@ class Input extends StatefulWidget {
 class _InputState extends State<Input> {
   bool _sendButtonVisible = false;
   final _textController = TextEditingController();
+  late final FocusNode _inputFocusNode;
 
   @override
   void initState() {
     super.initState();
     _textController.addListener(_handleTextControllerChange);
+    _inputFocusNode = FocusNode();
   }
 
   @override
   void dispose() {
+    _inputFocusNode.dispose();
     _textController.dispose();
     super.dispose();
   }
@@ -84,54 +87,58 @@ class _InputState extends State<Input> {
   Widget build(BuildContext context) {
     final _query = MediaQuery.of(context);
 
-    return Material(
-      borderRadius: InheritedChatTheme.of(context).theme.inputBorderRadius,
-      color: InheritedChatTheme.of(context).theme.inputBackgroundColor,
-      child: Container(
-        padding: EdgeInsets.fromLTRB(
-          24 + _query.padding.left,
-          20,
-          24 + _query.padding.right,
-          20 + _query.viewInsets.bottom + _query.padding.bottom,
-        ),
-        child: Row(
-          children: [
-            if (widget.onAttachmentPressed != null) _leftWidget(),
-            Expanded(
-              child: TextField(
-                controller: _textController,
-                decoration: InputDecoration.collapsed(
-                  hintStyle: InheritedChatTheme.of(context)
+    return GestureDetector(
+      onTap: () => _inputFocusNode.requestFocus(),
+      child: Material(
+        borderRadius: InheritedChatTheme.of(context).theme.inputBorderRadius,
+        color: InheritedChatTheme.of(context).theme.inputBackgroundColor,
+        child: Container(
+          padding: EdgeInsets.fromLTRB(
+            24 + _query.padding.left,
+            20,
+            24 + _query.padding.right,
+            20 + _query.viewInsets.bottom + _query.padding.bottom,
+          ),
+          child: Row(
+            children: [
+              if (widget.onAttachmentPressed != null) _leftWidget(),
+              Expanded(
+                child: TextField(
+                  controller: _textController,
+                  decoration: InputDecoration.collapsed(
+                    hintStyle: InheritedChatTheme.of(context)
+                        .theme
+                        .inputTextStyle
+                        .copyWith(
+                          color: InheritedChatTheme.of(context)
+                              .theme
+                              .inputTextColor
+                              .withOpacity(0.5),
+                        ),
+                    hintText: InheritedL10n.of(context).l10n.inputPlaceholder,
+                  ),
+                  focusNode: _inputFocusNode,
+                  keyboardType: TextInputType.multiline,
+                  maxLines: 5,
+                  minLines: 1,
+                  style: InheritedChatTheme.of(context)
                       .theme
                       .inputTextStyle
                       .copyWith(
-                        color: InheritedChatTheme.of(context)
-                            .theme
-                            .inputTextColor
-                            .withOpacity(0.5),
+                        color:
+                            InheritedChatTheme.of(context).theme.inputTextColor,
                       ),
-                  hintText: InheritedL10n.of(context).l10n.inputPlaceholder,
+                  textCapitalization: TextCapitalization.sentences,
                 ),
-                keyboardType: TextInputType.multiline,
-                maxLines: 5,
-                minLines: 1,
-                style: InheritedChatTheme.of(context)
-                    .theme
-                    .inputTextStyle
-                    .copyWith(
-                      color:
-                          InheritedChatTheme.of(context).theme.inputTextColor,
-                    ),
-                textCapitalization: TextCapitalization.sentences,
               ),
-            ),
-            Visibility(
-              visible: _sendButtonVisible,
-              child: SendButton(
-                onPressed: _handleSendPressed,
+              Visibility(
+                visible: _sendButtonVisible,
+                child: SendButton(
+                  onPressed: _handleSendPressed,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_chat_ui
 description: >
   Actively maintained, community-driven chat UI implementation with an
   optional Firebase BaaS.
-version: 1.1.2
+version: 1.1.3
 homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_ui
 


### PR DESCRIPTION
This is ready to be merged. 

### What does it do?

- Added a `FocusNode` to `_InputState` and its `TextField`. 
- Requesting focus on that node with a `GestureDetector` which wraps the entire composition input area (the part that has the border radius and contains the field itself, etc). 
- The majority of the changed lines are due to increased indentation from the widget wrapping; the only new lines inside `build(...)` are the new, outer `GestureDetector` (and its `onTap`), and `focusNode: _inputFocusNode,` inside the `TextField`.
- Tapping "off" still causes the field to lose focus. 

### Why is it needed?

- This makes it easier for the user to bring up the keyboard, improving usability.
- Before this, if the user tapped a little high or low --but still reasonably "on the input area"-- the chat/app might appear
unresponsive.

### How to test it?

- Tap near the very edge(s) of the input area (where the padding around the `TextField` is), and it should focus the field and bring up the keyboard. 

### Related issues/PRs

- No related issue (I thought I'd just make this PR directly). 
