### PR TITLE
On text changed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.5
+
+- Adds [onTextChanged] callback to detect when the user is typing
+
 ## 1.1.4
 
 - Remove automatic scroll to bottom for incoming messages

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -35,6 +35,7 @@ class Chat extends StatefulWidget {
     this.onMessageTap,
     this.onPreviewDataFetched,
     required this.onSendPressed,
+    this.onTextChanged,
     this.showUserAvatars = false,
     this.showUserNames = false,
     this.theme = const DefaultChatTheme(),
@@ -86,6 +87,9 @@ class Chat extends StatefulWidget {
 
   /// See [Input.onSendPressed]
   final void Function(types.PartialText) onSendPressed;
+
+  /// See [Input.onTextChanged]
+  final void Function(types.PartialText)? onTextChanged;
 
   /// See [Message.showUserAvatars]
   final bool showUserAvatars;
@@ -319,6 +323,7 @@ class _ChatState extends State<Chat> {
                         isAttachmentUploading: widget.isAttachmentUploading,
                         onAttachmentPressed: widget.onAttachmentPressed,
                         onSendPressed: widget.onSendPressed,
+                        onTextChanged: widget.onTextChanged,
                       ),
                     ],
                   ),

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -147,8 +147,8 @@ class _InputState extends State<Input> {
                       child: TextField(
                         controller: _textController,
                         onChanged: widget.onTextChanged != null
-                        ? (text) => _onTextChanged(text)
-                        : null,
+                            ? (text) => _onTextChanged(text)
+                            : null,
                         decoration: InputDecoration.collapsed(
                           hintStyle: InheritedChatTheme.of(context)
                               .theme

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
 import 'attachment_button.dart';
 import 'inherited_chat_theme.dart';
 import 'inherited_l10n.dart';
@@ -23,6 +24,7 @@ class Input extends StatefulWidget {
     this.isAttachmentUploading,
     this.onAttachmentPressed,
     required this.onSendPressed,
+    this.onTextChanged,
   }) : super(key: key);
 
   /// See [AttachmentButton.onPressed]
@@ -37,6 +39,9 @@ class Input extends StatefulWidget {
   /// Will be called on [SendButton] tap. Has [types.PartialText] which can
   /// be transformed to [types.TextMessage] and added to the messages list.
   final void Function(types.PartialText) onSendPressed;
+
+  /// Will be called whenever the text inside [TextField] changes
+  final void Function(types.PartialText)? onTextChanged;
 
   @override
   _InputState createState() => _InputState();
@@ -141,6 +146,9 @@ class _InputState extends State<Input> {
                     Expanded(
                       child: TextField(
                         controller: _textController,
+                        onChanged: widget.onTextChanged != null
+                        ? (text) => _onTextChanged(text)
+                        : null,
                         decoration: InputDecoration.collapsed(
                           hintStyle: InheritedChatTheme.of(context)
                               .theme
@@ -183,5 +191,10 @@ class _InputState extends State<Input> {
         ),
       ),
     );
+  }
+
+  void _onTextChanged(String? text) {
+    final partialText = types.PartialText(text: _textController.text.trim());
+    widget.onTextChanged!(partialText);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_chat_ui
 description: >
   Actively maintained, community-driven chat UI implementation with an
   optional Firebase BaaS.
-version: 1.1.4
+version: 1.1.5
 homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_ui
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a callback so we can know when the text changed

### Why is it needed?

It is useful when we want, for example, show a typing indicator. In that case, we need a way to know when the user started typing.

### How to test it?

Pass a `onTextChanged` callback to `Chat`

### Related issues/PRs

None
