### PR TITLE
Add support to set custom sendingIcon

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -70,6 +70,7 @@ abstract class ChatTheme {
     required this.receivedMessageLinkTitleTextStyle,
     required this.secondaryColor,
     required this.seenIcon,
+    required this.sendingIcon,
     required this.sendButtonIcon,
     required this.sentMessageBodyTextStyle,
     required this.sentMessageCaptionTextStyle,
@@ -147,6 +148,9 @@ abstract class ChatTheme {
 
   /// Icon for message's `seen` status. For the best look use size of 16.
   final Widget? seenIcon;
+
+  /// Icon for message's `sending` status. For the best look use size of 16.
+  final Widget? sendingIcon;
 
   /// Icon for send button
   final Widget? sendButtonIcon;
@@ -252,6 +256,7 @@ class DefaultChatTheme extends ChatTheme {
     ),
     Color secondaryColor = SECONDARY,
     Widget? seenIcon,
+    Widget? sendingIcon,
     Widget? sendButtonIcon,
     TextStyle sentMessageBodyTextStyle = const TextStyle(
       color: NEUTRAL_7,
@@ -319,6 +324,7 @@ class DefaultChatTheme extends ChatTheme {
           receivedMessageLinkTitleTextStyle: receivedMessageLinkTitleTextStyle,
           secondaryColor: secondaryColor,
           seenIcon: seenIcon,
+          sendingIcon: sendingIcon,
           sendButtonIcon: sendButtonIcon,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,
           sentMessageCaptionTextStyle: sentMessageCaptionTextStyle,
@@ -403,6 +409,7 @@ class DarkChatTheme extends ChatTheme {
     ),
     Color secondaryColor = SECONDARY_DARK,
     Widget? seenIcon,
+    Widget? sendingIcon,
     Widget? sendButtonIcon,
     TextStyle sentMessageBodyTextStyle = const TextStyle(
       color: NEUTRAL_7,
@@ -470,6 +477,7 @@ class DarkChatTheme extends ChatTheme {
           receivedMessageLinkTitleTextStyle: receivedMessageLinkTitleTextStyle,
           secondaryColor: secondaryColor,
           seenIcon: seenIcon,
+          sendingIcon: sendingIcon,
           sendButtonIcon: sendButtonIcon,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,
           sentMessageCaptionTextStyle: sentMessageCaptionTextStyle,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -153,19 +153,21 @@ class Message extends StatelessWidget {
                 package: 'flutter_chat_ui',
               );
       case types.Status.sending:
-        return Center(
-          child: SizedBox(
-            height: 10,
-            width: 10,
-            child: CircularProgressIndicator(
-              backgroundColor: Colors.transparent,
-              strokeWidth: 1.5,
-              valueColor: AlwaysStoppedAnimation<Color>(
-                InheritedChatTheme.of(context).theme.primaryColor,
-              ),
-            ),
-          ),
-        );
+        return InheritedChatTheme.of(context).theme.sendingIcon != null
+            ? InheritedChatTheme.of(context).theme.sendingIcon!
+            : Center(
+                child: SizedBox(
+                  height: 10,
+                  width: 10,
+                  child: CircularProgressIndicator(
+                    backgroundColor: Colors.transparent,
+                    strokeWidth: 1.5,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      InheritedChatTheme.of(context).theme.primaryColor,
+                    ),
+                  ),
+                ),
+              );
       default:
         return const SizedBox();
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add parameter `sendingIcon` to `ChatTheme`.  

### Why is it needed?

A more customizable `ChatTheme` makes the library flexible.

### How to test it?

Pass the desired `Widget` as an argument to `sendingIcon` of `DefaultChatTheme`.


### Related issues/PRs

Let us know if this is related to any issue/pull request.
