### PR TITLE
Allow setting the visibility of the SendButton

### DIFF
--- a/lib/flutter_chat_ui.dart
+++ b/lib/flutter_chat_ui.dart
@@ -2,6 +2,7 @@ library flutter_chat_ui;
 
 export 'src/chat_l10n.dart';
 export 'src/chat_theme.dart';
+export 'src/models/send_button_visibility_mode.dart';
 export 'src/util.dart' show formatBytes;
 export 'src/widgets/attachment_button.dart';
 export 'src/widgets/chat.dart';

--- a/lib/src/models/send_button_visibility_mode.dart
+++ b/lib/src/models/send_button_visibility_mode.dart
@@ -1,0 +1,9 @@
+/// Used to toggle the visibility behavior of the [SendButton] based on the
+/// [TextField] state inside the [Input] widget.
+enum SendButtonVisibilityMode {
+  /// Always show the [SendButton] regardless of the [TextField] state.
+  always,
+
+  /// The [SendButton] will only appear when the [TextField] is not empty.
+  editing,
+}

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -1,15 +1,18 @@
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/src/widgets/inherited_l10n.dart';
 import 'package:intl/intl.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+
 import '../chat_l10n.dart';
 import '../chat_theme.dart';
 import '../conditional/conditional.dart';
 import '../models/date_header.dart';
 import '../models/message_spacer.dart';
 import '../models/preview_image.dart';
+import '../models/send_button_visibility_mode.dart';
 import '../util.dart';
 import 'chat_list.dart';
 import 'inherited_chat_theme.dart';
@@ -40,6 +43,7 @@ class Chat extends StatefulWidget {
     this.onPreviewDataFetched,
     required this.onSendPressed,
     this.onTextChanged,
+    this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.showUserAvatars = false,
     this.showUserNames = false,
     this.theme = const DefaultChatTheme(),
@@ -118,6 +122,12 @@ class Chat extends StatefulWidget {
 
   /// See [Input.onTextChanged]
   final void Function(String)? onTextChanged;
+
+  /// Controls the visibility behavior of the [SendButton] based on the
+  /// [TextField] state inside the [Input] widget.
+  ///
+  /// Defaults to [SendButtonVisibilityMode.editing].
+  final SendButtonVisibilityMode sendButtonVisibilityMode;
 
   /// See [Message.showUserAvatars]
   final bool showUserAvatars;
@@ -364,6 +374,8 @@ class _ChatState extends State<Chat> {
                         onAttachmentPressed: widget.onAttachmentPressed,
                         onSendPressed: widget.onSendPressed,
                         onTextChanged: widget.onTextChanged,
+                        sendButtonVisibilityMode:
+                            widget.sendButtonVisibilityMode,
                       ),
                     ],
                   ),

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
+import '../models/send_button_visibility_mode.dart';
 import 'attachment_button.dart';
 import 'inherited_chat_theme.dart';
 import 'inherited_l10n.dart';
@@ -24,6 +26,7 @@ class Input extends StatefulWidget {
     this.onAttachmentPressed,
     required this.onSendPressed,
     this.onTextChanged,
+    required this.sendButtonVisibilityMode,
   }) : super(key: key);
 
   /// See [AttachmentButton.onPressed]
@@ -42,6 +45,9 @@ class Input extends StatefulWidget {
   /// Will be called whenever the text inside [TextField] changes
   final void Function(String)? onTextChanged;
 
+  /// See [Chat.sendButtonVisibilityMode]
+  final SendButtonVisibilityMode sendButtonVisibilityMode;
+
   @override
   _InputState createState() => _InputState();
 }
@@ -55,7 +61,11 @@ class _InputState extends State<Input> {
   @override
   void initState() {
     super.initState();
-    _textController.addListener(_handleTextControllerChange);
+    // When sendButtonVisibilityMode is set to SendButtonVisibilityMode.editing,
+    // we will need to add a listener to check if _textController is empty.
+    if (widget.sendButtonVisibilityMode == SendButtonVisibilityMode.editing) {
+      _textController.addListener(_handleTextControllerChange);
+    }
   }
 
   @override
@@ -179,7 +189,9 @@ class _InputState extends State<Input> {
                       ),
                     ),
                     Visibility(
-                      visible: _sendButtonVisible,
+                      visible: widget.sendButtonVisibilityMode ==
+                              SendButtonVisibilityMode.always ||
+                          _sendButtonVisible,
                       child: SendButton(
                         onPressed: _handleSendPressed,
                       ),

--- a/test/flutter_chat_ui_test.dart
+++ b/test/flutter_chat_ui_test.dart
@@ -1,5 +1,7 @@
+import 'input.test.dart' as input_test;
 import 'util.test.dart' as util_test;
 
 void main() {
+  input_test.main();
   util_test.main();
 }

--- a/test/input.test.dart
+++ b/test/input.test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('sendButtonVisibilityMode', () {
+    testWidgets(
+        'The SendButton should always be visible when sendButtonVisibilityMode is set to SendButtonVisibilityMode.always',
+        (WidgetTester tester) async {
+      // Build the Chat widget.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Chat(
+              messages: [],
+              onSendPressed: (types.PartialText message) {},
+              sendButtonVisibilityMode: SendButtonVisibilityMode.always,
+              user:
+                  const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+            ),
+          ),
+        ),
+      );
+      // Trigger a frame.
+      await tester.pump();
+
+      // The SendButton should exist in the widget tree.
+      expect(find.byType(SendButton), findsOneWidget);
+    });
+
+    testWidgets(
+        'The SendButton should be invisible only when sendButtonVisibilityMode is not specified and the TextField is empty',
+        (WidgetTester tester) async {
+      // Build the Chat widget.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Chat(
+              messages: [],
+              onSendPressed: (types.PartialText message) {},
+              user:
+                  const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+            ),
+          ),
+        ),
+      );
+      // Trigger a frame.
+      await tester.pump();
+
+      // The SendButton should not exist in the widget tree.
+      expect(find.byType(SendButton), findsNothing);
+    });
+
+    testWidgets(
+        'The SendButton should be visible only when sendButtonVisibilityMode is not specified and the TextField is not empty',
+        (WidgetTester tester) async {
+      // Build the Chat widget.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Chat(
+              messages: [],
+              onSendPressed: (types.PartialText message) {},
+              user:
+                  const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+            ),
+          ),
+        ),
+      );
+      // Trigger a frame.
+      await tester.pump();
+      // Enter 'hi' into the TextField.
+      await tester.enterText(find.byType(TextField), 'hi');
+      // Trigger a frame.
+      await tester.pump();
+
+      // The SendButton should exist in the widget tree.
+      expect(find.byType(SendButton), findsOneWidget);
+    });
+  });
+}

--- a/test/input.test.dart
+++ b/test/input.test.dart
@@ -13,7 +13,7 @@ void main() {
         MaterialApp(
           home: Material(
             child: Chat(
-              messages: [],
+              messages: const [],
               onSendPressed: (types.PartialText message) {},
               sendButtonVisibilityMode: SendButtonVisibilityMode.always,
               user:
@@ -37,7 +37,7 @@ void main() {
         MaterialApp(
           home: Material(
             child: Chat(
-              messages: [],
+              messages: const [],
               onSendPressed: (types.PartialText message) {},
               user:
                   const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
@@ -60,7 +60,7 @@ void main() {
         MaterialApp(
           home: Material(
             child: Chat(
-              messages: [],
+              messages: const [],
               onSendPressed: (types.PartialText message) {},
               user:
                   const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),


### PR DESCRIPTION
### What does it do?

It adds the ability to change the visibility of the `SendButton` by introducing a new enum property called `sendButtonVisibilityMode` to the `Chat` widget.

When `sendButtonVisibilityMode` parameter passed into the `Chat` widget, the `Input` widget will check if the parameter is set to `SendButtonVisibilityMode.always`. If it is, the `SendButton` always be visible regardless of the `TextField` state. 

If it is set to `SendButtonVisibilityMode.editing`, the `SendButton` will be visible only if the `TextField` is not empty.

The `sendButtonVisibilityMode` parameter defaults to `SendButtonVisibilityMode.editing` to maintain the existing behavior.

### Why is it needed?

It will increase the flexibility when displaying the `SendButton`.

### How to test it?

I've added some widget tests to not break the existing behavior and make sure everything works properly.

### Related issues/PRs

Related #62 
