### PR TITLE
Feature/add background color for imaged avatar

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -79,6 +79,7 @@ abstract class ChatTheme {
     required this.sentMessageLinkTitleTextStyle,
     required this.userAvatarNameColors,
     required this.userAvatarTextStyle,
+    required this.userImagedAvatarBackgroundColor,
     required this.userNameTextStyle,
   });
 
@@ -173,13 +174,18 @@ abstract class ChatTheme {
   /// Text style used for displaying link title on sent messages
   final TextStyle sentMessageLinkTitleTextStyle;
 
-  /// Colors used as backgrounds for user avatars and corresponded user names.
+  /// Colors used as backgrounds for user avatars with no image and so,
+  /// corresponding user names.
   /// Calculated based on a user ID, so unique across the whole app.
   final List<Color> userAvatarNameColors;
 
   /// Text style used for displaying initials on user avatar if no
   /// image is provided
   final TextStyle userAvatarTextStyle;
+
+  /// Color used as background for user avatar if an image is provided.
+  /// Visible if the provided image has some transparent parts.
+  final Color userImagedAvatarBackgroundColor;
 
   /// User names text style. Color will be overwritten with [userAvatarNameColors].
   final TextStyle userNameTextStyle;
@@ -295,6 +301,7 @@ class DefaultChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
+    Color userImagedAvatarBackgroundColor = NEUTRAL_7,
     TextStyle userNameTextStyle = const TextStyle(
       fontFamily: 'Avenir',
       fontSize: 12,
@@ -334,6 +341,7 @@ class DefaultChatTheme extends ChatTheme {
           sentMessageLinkTitleTextStyle: sentMessageLinkTitleTextStyle,
           userAvatarNameColors: userAvatarNameColors,
           userAvatarTextStyle: userAvatarTextStyle,
+          userImagedAvatarBackgroundColor: userImagedAvatarBackgroundColor,
           userNameTextStyle: userNameTextStyle,
         );
 }
@@ -448,6 +456,7 @@ class DarkChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
+    Color userImagedAvatarBackgroundColor = DARK,
     TextStyle userNameTextStyle = const TextStyle(
       fontFamily: 'Avenir',
       fontSize: 12,
@@ -487,6 +496,7 @@ class DarkChatTheme extends ChatTheme {
           sentMessageLinkTitleTextStyle: sentMessageLinkTitleTextStyle,
           userAvatarNameColors: userAvatarNameColors,
           userAvatarTextStyle: userAvatarTextStyle,
+          userImagedAvatarBackgroundColor: userImagedAvatarBackgroundColor,
           userNameTextStyle: userNameTextStyle,
         );
 }

--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -456,7 +456,7 @@ class DarkChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
-    Color userImagedAvatarBackgroundColor = DARK,
+    Color userImagedAvatarBackgroundColor = SECONDARY_DARK,
     TextStyle userNameTextStyle = const TextStyle(
       fontFamily: 'Avenir',
       fontSize: 12,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -72,6 +72,8 @@ class Message extends StatelessWidget {
     );
     final hasImage = message.author.imageUrl != null;
     final name = getUserName(message.author);
+    final userImagedAvatarBackgroundColor =
+      InheritedChatTheme.of(context).theme.userImagedAvatarBackgroundColor;
 
     return showAvatar
         ? Container(
@@ -79,7 +81,9 @@ class Message extends StatelessWidget {
             child: CircleAvatar(
               backgroundImage:
                   hasImage ? NetworkImage(message.author.imageUrl!) : null,
-              backgroundColor: hasImage ? InheritedChatTheme.of(context).theme.userImagedAvatarBackgroundColor : color,
+              backgroundColor: hasImage
+                ? userImagedAvatarBackgroundColor
+                : color,
               radius: 16,
               child: !hasImage
                   ? Text(

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -79,7 +79,7 @@ class Message extends StatelessWidget {
             child: CircleAvatar(
               backgroundImage:
                   hasImage ? NetworkImage(message.author.imageUrl!) : null,
-              backgroundColor: hasImage ? InheritedChatTheme.of(context).theme.userImagedAvatarBackgroundColor, : color,
+              backgroundColor: hasImage ? InheritedChatTheme.of(context).theme.userImagedAvatarBackgroundColor : color,
               radius: 16,
               child: !hasImage
                   ? Text(

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -79,7 +79,7 @@ class Message extends StatelessWidget {
             child: CircleAvatar(
               backgroundImage:
                   hasImage ? NetworkImage(message.author.imageUrl!) : null,
-              backgroundColor: hasImage ? null : color,
+              backgroundColor: hasImage ? InheritedChatTheme.of(context).theme.userImagedAvatarBackgroundColor, : color,
               radius: 16,
               child: !hasImage
                   ? Text(


### PR DESCRIPTION
Hello! thanks for this great plugin that has been very useful for me 🙌 

I encountered some limitations for a specific case, which is described below, and thought it might be useful to publish my contribution to resolve it, in order to make the library more flexible. 

### What does it do?

- add parameter `userImagedAvatarBackgroundColor` to `ChatTheme` ;
- use it as user avatar `CircleAvatar`'s background color, in the case an image is used.

---

### Why is it needed?

A user avatar with an image and **transparent parts** has currently a green background color which is not customizable.
This contribution allows people to customize this color.

#### The current default behavior (<= [v1.2.0 release](https://github.com/flyerhq/flutter_chat_ui/releases/tag/v1.2.0))
<img width="234" alt="old" src="https://user-images.githubusercontent.com/25340482/130977256-9b4affcd-0a96-42f7-a4fc-950e2e8cc07e.png">

#### The new default behavior, for the `DefaultChatTheme`
<img width="234" alt="new-light" src="https://user-images.githubusercontent.com/25340482/130977255-c7cce5f4-3b53-4247-9f61-db4356a42f11.png">

#### The new default behavior, for the `DarkChatTheme`
<img width="234" alt="new-dark" src="https://user-images.githubusercontent.com/25340482/130977253-b6f8cebf-3df2-46e5-b1d1-7ec3d5196889.png">

The existing parameter `userAvatarNameColors`, which is used for username color and avatar background color behind user initials if no image is provided, could not really be used here. This new color is mostly driven in an esthetic way, in order to fit with the other `ChatTheme` parameters.

---

### How to test it?

Put a transparent image as a user avatar (displayed on received messages only) and you should not see the green default background color. Customize it by defining a new `userImagedAvatarBackgroundColor` color to your theme.

---

### Related issues/PRs

None