### PR TITLE
Add onTextFieldTap parameter

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -42,6 +42,7 @@ class Chat extends StatefulWidget {
     this.onMessageTap,
     this.onPreviewDataFetched,
     required this.onSendPressed,
+    this.onTextFieldTap,
     this.onTextChanged,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.showUserAvatars = false,
@@ -126,6 +127,9 @@ class Chat extends StatefulWidget {
 
   /// See [Input.onTextChanged]
   final void Function(String)? onTextChanged;
+
+  /// See [Input.onTextFieldTap]
+  final void Function()? onTextFieldTap;
 
   /// See [Input.sendButtonVisibilityMode]
   final SendButtonVisibilityMode sendButtonVisibilityMode;
@@ -378,6 +382,7 @@ class _ChatState extends State<Chat> {
                           onAttachmentPressed: widget.onAttachmentPressed,
                           onSendPressed: widget.onSendPressed,
                           onTextChanged: widget.onTextChanged,
+                          onTextFieldTap: widget.onTextFieldTap,
                           sendButtonVisibilityMode:
                               widget.sendButtonVisibilityMode,
                         ),

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -25,6 +25,7 @@ class Input extends StatefulWidget {
     this.onAttachmentPressed,
     required this.onSendPressed,
     this.onTextChanged,
+    this.onTextFieldTap,
     required this.sendButtonVisibilityMode,
   }) : super(key: key);
 
@@ -43,6 +44,9 @@ class Input extends StatefulWidget {
 
   /// Will be called whenever the text inside [TextField] changes
   final void Function(String)? onTextChanged;
+
+  /// Will be called on [TextField] tap.
+  final void Function()? onTextFieldTap;
 
   /// Controls the visibility behavior of the [SendButton] based on the
   /// [TextField] state inside the [Input] widget.
@@ -190,6 +194,7 @@ class _InputState extends State<Input> {
                           maxLines: 5,
                           minLines: 1,
                           onChanged: widget.onTextChanged,
+                          onTap: widget.onTextFieldTap,
                           style: InheritedChatTheme.of(context)
                               .theme
                               .inputTextStyle


### PR DESCRIPTION
### What does it do?

It allows developers to specify an `onTap` function for the `TextField` inside the `Input` by adding `onTextFieldTap` parameter to the `Chat`.

### Why is it needed?

I need it to be able to mark the received messages as `seen` when I tap on `TextField`. Most popular chat apps such as `Messenger`, `WhatsApp` also use this way.

### Related issues/PRs

None