### PR TITLE
feature: add tap on background callback

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/src/widgets/inherited_l10n.dart';
 import 'package:intl/intl.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+
 import '../chat_l10n.dart';
 import '../chat_theme.dart';
 import '../conditional/conditional.dart';
@@ -56,6 +58,7 @@ class Chat extends StatefulWidget {
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
     this.usePreviewData = true,
+    this.onBackgroundTap,
     required this.user,
   }) : super(key: key);
 
@@ -198,6 +201,9 @@ class Chat extends StatefulWidget {
 
   /// See [InheritedUser.user]
   final types.User user;
+
+  /// Called when users tap on the background
+  final void Function()? onBackgroundTap;
 
   @override
   _ChatState createState() => _ChatState();
@@ -405,8 +411,10 @@ class _ChatState extends State<Chat> {
                               child: _emptyStateBuilder(),
                             )
                           : GestureDetector(
-                              onTap: () =>
-                                  FocusManager.instance.primaryFocus?.unfocus(),
+                              onTap: () {
+                                FocusManager.instance.primaryFocus?.unfocus();
+                                widget.onBackgroundTap?.call();
+                              },
                               child: LayoutBuilder(
                                 builder: (BuildContext context,
                                         BoxConstraints constraints) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a callback when a user taps on the background of the chat

### Why is it needed?

I need to perform an action when a user taps on the background (I've a widget that I want to hide when the user taps on the background of the chat)

### How to test it?

Add `onBackgroundTap` to the Chat widget.

### Related issues/PRs

None