### PR TITLE
Feature: customizable padding for date dividers

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -52,6 +52,7 @@ abstract class ChatTheme {
     required this.attachmentButtonIcon,
     required this.backgroundColor,
     required this.dateDividerTextStyle,
+    required this.dateDividerPadding,
     required this.deliveredIcon,
     required this.documentIcon,
     required this.emptyChatPlaceholderTextStyle,
@@ -96,6 +97,9 @@ abstract class ChatTheme {
 
   /// Text style of the date dividers
   final TextStyle dateDividerTextStyle;
+
+  /// Padding around date dividers
+  final EdgeInsets dateDividerPadding;
 
   /// Icon for message's `delivered` status. For the best look use size of 16.
   final Widget? deliveredIcon;
@@ -227,6 +231,10 @@ class DefaultChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.333,
     ),
+    EdgeInsets dateDividerPadding = const EdgeInsets.only(
+      bottom: 32,
+      top: 16,
+    ),
     Widget? deliveredIcon,
     Widget? documentIcon,
     TextStyle emptyChatPlaceholderTextStyle = const TextStyle(
@@ -341,6 +349,7 @@ class DefaultChatTheme extends ChatTheme {
           attachmentButtonIcon: attachmentButtonIcon,
           backgroundColor: backgroundColor,
           dateDividerTextStyle: dateDividerTextStyle,
+          dateDividerPadding: dateDividerPadding,
           deliveredIcon: deliveredIcon,
           documentIcon: documentIcon,
           emptyChatPlaceholderTextStyle: emptyChatPlaceholderTextStyle,
@@ -395,6 +404,10 @@ class DarkChatTheme extends ChatTheme {
       fontSize: 12,
       fontWeight: FontWeight.w800,
       height: 1.333,
+    ),
+    EdgeInsets dateDividerPadding = const EdgeInsets.only(
+      bottom: 32,
+      top: 16,
     ),
     Widget? deliveredIcon,
     Widget? documentIcon,
@@ -510,6 +523,7 @@ class DarkChatTheme extends ChatTheme {
           attachmentButtonIcon: attachmentButtonIcon,
           backgroundColor: backgroundColor,
           dateDividerTextStyle: dateDividerTextStyle,
+          dateDividerPadding: dateDividerPadding,
           deliveredIcon: deliveredIcon,
           documentIcon: documentIcon,
           emptyChatPlaceholderTextStyle: emptyChatPlaceholderTextStyle,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -307,10 +307,7 @@ class _ChatState extends State<Chat> {
     if (object is DateHeader) {
       return Container(
         alignment: Alignment.center,
-        margin: const EdgeInsets.only(
-          bottom: 32,
-          top: 16,
-        ),
+        margin: widget.theme.dateDividerPadding,
         child: Text(
           object.text,
           style: widget.theme.dateDividerTextStyle,


### PR DESCRIPTION
### What does it do?
Moves date divider padding from a constant `EdgeInsets` value to `ChatTheme` field to allow changing it

### Why is it needed?
Previously, padding around date dividers was always set to 32 on top, and 16 on bottom. My design required these values to be smaller, so i extracted them to theme, to allow configuration. I think this small change extends customization possibilities of the library.

### How to test it?
Set `dateDividerPadding` field in `ChatThem` to any desired `EdgeInsets` and observe changes on the UI

### Related issues/PRs
None
