### PR TITLE
Implemented configurable padding for status icons

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -82,6 +82,7 @@ abstract class ChatTheme {
     required this.sentMessageDocumentIconColor,
     required this.sentMessageLinkDescriptionTextStyle,
     required this.sentMessageLinkTitleTextStyle,
+    required this.statusIconPadding,
     required this.userAvatarImageBackgroundColor,
     required this.userAvatarNameColors,
     required this.userAvatarTextStyle,
@@ -193,6 +194,9 @@ abstract class ChatTheme {
 
   /// Text style used for displaying link title on sent messages
   final TextStyle sentMessageLinkTitleTextStyle;
+
+  /// Insets of message status icon
+  final EdgeInsets statusIconPadding;
 
   /// Color used as a background for user avatar if an image is provided.
   /// Visible if the image has some transparent parts.
@@ -322,6 +326,7 @@ class DefaultChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.375,
     ),
+    EdgeInsets statusIconPadding = const EdgeInsets.symmetric(horizontal: 4),
     Color userAvatarImageBackgroundColor = Colors.transparent,
     List<Color> userAvatarNameColors = colors,
     TextStyle userAvatarTextStyle = const TextStyle(
@@ -373,6 +378,7 @@ class DefaultChatTheme extends ChatTheme {
           sentMessageLinkDescriptionTextStyle:
               sentMessageLinkDescriptionTextStyle,
           sentMessageLinkTitleTextStyle: sentMessageLinkTitleTextStyle,
+          statusIconPadding: statusIconPadding,
           userAvatarImageBackgroundColor: userAvatarImageBackgroundColor,
           userAvatarNameColors: userAvatarNameColors,
           userAvatarTextStyle: userAvatarTextStyle,
@@ -491,6 +497,7 @@ class DarkChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.375,
     ),
+    EdgeInsets statusIconPadding = const EdgeInsets.symmetric(horizontal: 4),
     Color userAvatarImageBackgroundColor = Colors.transparent,
     List<Color> userAvatarNameColors = colors,
     TextStyle userAvatarTextStyle = const TextStyle(
@@ -542,6 +549,7 @@ class DarkChatTheme extends ChatTheme {
           sentMessageLinkDescriptionTextStyle:
               sentMessageLinkDescriptionTextStyle,
           sentMessageLinkTitleTextStyle: sentMessageLinkTitleTextStyle,
+          statusIconPadding: statusIconPadding,
           userAvatarImageBackgroundColor: userAvatarImageBackgroundColor,
           userAvatarNameColors: userAvatarNameColors,
           userAvatarTextStyle: userAvatarTextStyle,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -291,14 +291,8 @@ class Message extends StatelessWidget {
           ),
           if (_currentUserIsAuthor)
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Center(
-                child: SizedBox(
-                  height: 16,
-                  width: 16,
-                  child: showStatus ? _statusBuilder(context) : null,
-                ),
-              ),
+              padding: InheritedChatTheme.of(context).theme.statusIconPadding,
+              child: showStatus ? _statusBuilder(context) : null,
             ),
         ],
       ),


### PR DESCRIPTION
### What does it do?

Removes unnecessary `SizedBox` of size 16 around status icons and implements additional theme param to allow change of padding around Status icons

### Why is it needed?

Previously status icons weren't customizable - the only thing that could be changed was the icon itself, but not it's size or position. This also caused all messages to have a padding of 24 (16 for icon and symmetric padding of 4 on both sides of icon) and changing the distance between message bubble and side of screen was not possible. This change extends customization options without changing the default look of library components

### How to test it?

Change the value of `statusIconPadding` in `ChatTheme` instances, or use different size icons for statuses, to see that they are not constrained to 16x16 size.