### PR TITLE
Added methods to detect status icon tap and long press

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -48,7 +48,9 @@ class Chat extends StatefulWidget {
     this.onEndReached,
     this.onEndReachedThreshold,
     this.onMessageLongPress,
+    this.onMessageStatusLongPress,
     this.onMessageTap,
+    this.onMessageStatusTap,
     this.onPreviewDataFetched,
     required this.onSendPressed,
     this.onTextChanged,
@@ -162,8 +164,14 @@ class Chat extends StatefulWidget {
   /// See [Message.onMessageLongPress]
   final void Function(types.Message)? onMessageLongPress;
 
+  /// See [Message.onMessageStatusLongPress]
+  final void Function(types.Message)? onMessageStatusLongPress;
+
   /// See [Message.onMessageTap]
   final void Function(types.Message)? onMessageTap;
+
+  /// See [Message.onMessageStatusTap]
+  final void Function(types.Message)? onMessageStatusTap;
 
   /// See [Message.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -353,6 +361,7 @@ class _ChatState extends State<Chat> {
         message: message,
         messageWidth: _messageWidth,
         onMessageLongPress: widget.onMessageLongPress,
+        onMessageStatusLongPress: widget.onMessageStatusLongPress,
         onMessageTap: (tappedMessage) {
           if (tappedMessage is types.ImageMessage &&
               widget.disableImageGallery != true) {
@@ -361,6 +370,7 @@ class _ChatState extends State<Chat> {
 
           widget.onMessageTap?.call(tappedMessage);
         },
+        onMessageStatusTap: widget.onMessageStatusTap,
         onPreviewDataFetched: _onPreviewDataFetched,
         roundBorder: map['nextMessageInGroup'] == true,
         showAvatar: map['nextMessageInGroup'] == false,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -24,7 +24,9 @@ class Message extends StatelessWidget {
     required this.message,
     required this.messageWidth,
     this.onMessageLongPress,
+    this.onMessageStatusLongPress,
     this.onMessageTap,
+    this.onMessageStatusTap,
     this.onPreviewDataFetched,
     required this.roundBorder,
     required this.showAvatar,
@@ -75,8 +77,14 @@ class Message extends StatelessWidget {
   /// Called when user makes a long press on any message
   final void Function(types.Message)? onMessageLongPress;
 
+  /// Called when user makes a long press on status icon on any message
+  final void Function(types.Message)? onMessageStatusLongPress;
+
   /// Called when user taps on any message
   final void Function(types.Message)? onMessageTap;
+
+  /// Called when user taps on status icon on any message
+  final void Function(types.Message)? onMessageStatusTap;
 
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -314,7 +322,14 @@ class Message extends StatelessWidget {
           if (_currentUserIsAuthor)
             Padding(
               padding: InheritedChatTheme.of(context).theme.statusIconPadding,
-              child: showStatus ? _statusBuilder(context) : null,
+              child: showStatus
+                  ? GestureDetector(
+                      onLongPress: () =>
+                          onMessageStatusLongPress?.call(message),
+                      onTap: () => onMessageStatusTap?.call(message),
+                      child: _statusBuilder(context),
+                    )
+                  : null,
             ),
         ],
       ),


### PR DESCRIPTION
### What does it do?
There was no method to detect tap or long press on message status icon . This PR implements optional parameters to `Chat`: `onMessageStatusTap` and `onMessageStatusLongPress` to allow handling of these events.

### Why is it needed?
It's a common case to click on status icon if message is not sent, in order to attempt sending it again.

### How to test it?
Set `onMessageStatusTap` and `onMessageStatusLongPress` callbacks on `Chat` instance and click / longpress on one of status icons
