### PR TITLE
Add Traditional Chinese L10n

### DIFF
--- a/lib/src/chat_l10n.dart
+++ b/lib/src/chat_l10n.dart
@@ -226,3 +226,25 @@ class ChatL10nZhCN extends ChatL10n {
           sendButtonAccessibilityLabel: sendButtonAccessibilityLabel,
         );
 }
+
+/// Traditional Chinese l10n which extends [ChatL10n]
+@immutable
+class ChatL10nZhTW extends ChatL10n {
+  /// Creates Traditional Chinese l10n. Use this constructor if you want to
+  /// override only a couple of properties, otherwise create a new class
+  /// which extends [ChatL10n]
+  const ChatL10nZhTW({
+    String attachmentButtonAccessibilityLabel = '傳送多媒體',
+    String emptyChatPlaceholder = '尚無訊息',
+    String fileButtonAccessibilityLabel = '檔案',
+    String inputPlaceholder = '請輸入訊息...',
+    String sendButtonAccessibilityLabel = '傳送',
+  }) : super(
+          attachmentButtonAccessibilityLabel:
+              attachmentButtonAccessibilityLabel,
+          emptyChatPlaceholder: emptyChatPlaceholder,
+          fileButtonAccessibilityLabel: fileButtonAccessibilityLabel,
+          inputPlaceholder: inputPlaceholder,
+          sendButtonAccessibilityLabel: sendButtonAccessibilityLabel,
+        );
+}


### PR DESCRIPTION
* add Traditional Chinese L10n

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds support for Traditional Chinese (繁體中文-台灣).

### Why is it needed?

It can helps Taiwan user to use this project.

### How to test it?

Provide "const ChatL10nZhTW()" for property "l10n".

### Related issues/PRs

None.
