### PR TITLE
onMessageTap/1 onMessageLongPress/1 Add Parameter BuildContext context

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -139,7 +140,7 @@ class _ChatPageState extends State<ChatPage> {
     }
   }
 
-  void _handleMessageTap(types.Message message) async {
+  void _handleMessageTap(BuildContext context, types.Message message) async {
     if (message is types.FileMessage) {
       await OpenFile.open(message.uri);
     }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/src/widgets/inherited_l10n.dart';
 import 'package:intl/intl.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+
 import '../chat_l10n.dart';
 import '../chat_theme.dart';
 import '../conditional/conditional.dart';
@@ -166,7 +168,7 @@ class Chat extends StatefulWidget {
   final double? onEndReachedThreshold;
 
   /// See [Message.onMessageLongPress]
-  final void Function(types.Message)? onMessageLongPress;
+  final void Function(BuildContext content, types.Message)? onMessageLongPress;
 
   /// See [Message.onMessageStatusLongPress]
   final void Function(types.Message)? onMessageStatusLongPress;
@@ -175,7 +177,7 @@ class Chat extends StatefulWidget {
   final void Function(types.Message)? onMessageStatusTap;
 
   /// See [Message.onMessageTap]
-  final void Function(types.Message)? onMessageTap;
+  final void Function(BuildContext context, types.Message)? onMessageTap;
 
   /// See [Message.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -368,13 +370,13 @@ class _ChatState extends State<Chat> {
         onMessageLongPress: widget.onMessageLongPress,
         onMessageStatusLongPress: widget.onMessageStatusLongPress,
         onMessageStatusTap: widget.onMessageStatusTap,
-        onMessageTap: (tappedMessage) {
+        onMessageTap: (content, tappedMessage) {
           if (tappedMessage is types.ImageMessage &&
               widget.disableImageGallery != true) {
             _onImagePressed(tappedMessage);
           }
 
-          widget.onMessageTap?.call(tappedMessage);
+          widget.onMessageTap?.call(content, tappedMessage);
         },
         onPreviewDataFetched: _onPreviewDataFetched,
         roundBorder: map['nextMessageInGroup'] == true,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
 import '../models/emoji_enlargement_behavior.dart';
 import '../util.dart';
 import 'file_message.dart';
@@ -79,7 +80,7 @@ class Message extends StatelessWidget {
   final void Function(types.User)? onAvatarTap;
 
   /// Called when user makes a long press on any message
-  final void Function(types.Message)? onMessageLongPress;
+  final void Function(BuildContext context, types.Message)? onMessageLongPress;
 
   /// Called when user makes a long press on status icon in any message
   final void Function(types.Message)? onMessageStatusLongPress;
@@ -88,7 +89,7 @@ class Message extends StatelessWidget {
   final void Function(types.Message)? onMessageStatusTap;
 
   /// Called when user taps on any message
-  final void Function(types.Message)? onMessageTap;
+  final void Function(BuildContext context, types.Message)? onMessageTap;
 
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -314,8 +315,8 @@ class Message extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 GestureDetector(
-                  onLongPress: () => onMessageLongPress?.call(message),
-                  onTap: () => onMessageTap?.call(message),
+                  onLongPress: () => onMessageLongPress?.call(context, message),
+                  onTap: () => onMessageTap?.call(context, message),
                   child: _bubbleBuilder(
                     context,
                     _borderRadius,


### PR DESCRIPTION
### What does it do?

onMessageTap/1 onMessageLongPress/1 Add Parameter BuildContext context
onMessageTap/1 onMessageLongPress/1 两个函数，添加参数 BuildContext context


### Why is it needed?

Easy to right-click menu location
便于右键菜单定位


### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
