### PR TITLE
add onMessageDoubleTap/2 for message _bubbleBuilder onDoubleTap

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -54,6 +54,7 @@ class Chat extends StatefulWidget {
     this.onMessageStatusLongPress,
     this.onMessageStatusTap,
     this.onMessageTap,
+    this.onMessageDoubleTap,
     this.onPreviewDataFetched,
     required this.onSendPressed,
     this.onTextChanged,
@@ -179,6 +180,8 @@ class Chat extends StatefulWidget {
 
   /// See [Message.onMessageTap]
   final void Function(BuildContext context, types.Message)? onMessageTap;
+
+  final void Function(BuildContext context, types.Message)? onMessageDoubleTap;
 
   /// See [Message.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -378,6 +381,11 @@ class _ChatState extends State<Chat> {
           }
 
           widget.onMessageTap?.call(context, tappedMessage);
+        },
+        onMessageDoubleTap: (content, tappedMessage) {
+          if (widget.onMessageDoubleTap != null) {
+            widget.onMessageDoubleTap?.call(content, tappedMessage);
+          }
         },
         onPreviewDataFetched: _onPreviewDataFetched,
         roundBorder: map['nextMessageInGroup'] == true,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -29,6 +29,7 @@ class Message extends StatelessWidget {
     this.onMessageStatusLongPress,
     this.onMessageStatusTap,
     this.onMessageTap,
+    this.onMessageDoubleTap,
     this.onPreviewDataFetched,
     required this.roundBorder,
     required this.showAvatar,
@@ -91,6 +92,9 @@ class Message extends StatelessWidget {
 
   /// Called when user taps on any message
   final void Function(BuildContext context, types.Message)? onMessageTap;
+
+  /// Called when user double taps on any message
+  final void Function(BuildContext context, types.Message)? onMessageDoubleTap;
 
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -317,6 +321,7 @@ class Message extends StatelessWidget {
               children: [
                 GestureDetector(
                   onLongPress: () => onMessageLongPress?.call(context, message),
+                  onDoubleTap: () => onMessageDoubleTap?.call(context, message),
                   onTap: () => onMessageTap?.call(context, message),
                   child: _bubbleBuilder(
                     context,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Some users are used to double-clicking a message to have the effect of a full-screen enlarged message; This method can be implemented

一些用户习惯了双击消息有一个全屏的放大消息的效果；该方法可以实现之

```
  void _onMessageDoubleTap(BuildContext c1, types.Message message) async {
    if (message is types.TextMessage) {
      Get.bottomSheet(
        GestureDetector(
          onTap: () {
            Get.back();
          },
          child: Container(
            width: Get.width,
            height: Get.height,
            // Creates insets from offsets from the left, top, right, and bottom.
            padding: EdgeInsets.fromLTRB(16, 24, 6, 10),
            alignment: Alignment.center,
            color: Colors.white,
            child: Center(
              child: Scrollbar(
                child: SingleChildScrollView(
                  scrollDirection: Axis.vertical,
                  child: ExtendedText(
                    message.text,
                    textAlign: TextAlign.left,
                    style: TextStyle(
                      color: Colors.black,
                      fontSize: 20,
                    ),
                  ),
                ),
              ),
            ),
          ),
        ),
        // 是否支持全屏弹出，默认false
        isScrollControlled: true,
        enableDrag: false,
      );
    }
  }

```

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
