### PR TITLE
Added sendButtonMargin to ChatTheme

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -80,6 +80,7 @@ abstract class ChatTheme {
     required this.secondaryColor,
     required this.seenIcon,
     required this.sendButtonIcon,
+    required this.sendButtonMargin,
     required this.sendingIcon,
     required this.sentEmojiMessageTextStyle,
     required this.sentMessageBodyTextStyle,
@@ -190,6 +191,9 @@ abstract class ChatTheme {
 
   /// Icon for send button
   final Widget? sendButtonIcon;
+
+  /// Margin of send button
+  final EdgeInsetsGeometry? sendButtonMargin;
 
   /// Icon for message's `sending` status. For the best look use size of 10.
   final Widget? sendingIcon;
@@ -316,6 +320,7 @@ class DefaultChatTheme extends ChatTheme {
     Color secondaryColor = secondary,
     Widget? seenIcon,
     Widget? sendButtonIcon,
+    EdgeInsetsGeometry? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     TextStyle sentMessageBodyTextStyle = const TextStyle(
@@ -391,6 +396,7 @@ class DefaultChatTheme extends ChatTheme {
           secondaryColor: secondaryColor,
           seenIcon: seenIcon,
           sendButtonIcon: sendButtonIcon,
+          sendButtonMargin: sendButtonMargin,
           sendingIcon: sendingIcon,
           sentEmojiMessageTextStyle: sentEmojiMessageTextStyle,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,
@@ -488,6 +494,7 @@ class DarkChatTheme extends ChatTheme {
     Color secondaryColor = secondaryDark,
     Widget? seenIcon,
     Widget? sendButtonIcon,
+    EdgeInsetsGeometry? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     TextStyle sentMessageBodyTextStyle = const TextStyle(
@@ -563,6 +570,7 @@ class DarkChatTheme extends ChatTheme {
           secondaryColor: secondaryColor,
           seenIcon: seenIcon,
           sendButtonIcon: sendButtonIcon,
+          sendButtonMargin: sendButtonMargin,
           sendingIcon: sendingIcon,
           sentEmojiMessageTextStyle: sentEmojiMessageTextStyle,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,

--- a/lib/src/widgets/send_button.dart
+++ b/lib/src/widgets/send_button.dart
@@ -17,16 +17,15 @@ class SendButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       height: 24,
-      margin: const EdgeInsets.only(left: 16),
+      margin: InheritedChatTheme.of(context).theme.sendButtonMargin ?? const EdgeInsets.only(left: 16),
       width: 24,
       child: IconButton(
-        icon: InheritedChatTheme.of(context).theme.sendButtonIcon != null
-            ? InheritedChatTheme.of(context).theme.sendButtonIcon!
-            : Image.asset(
-                'assets/icon-send.png',
-                color: InheritedChatTheme.of(context).theme.inputTextColor,
-                package: 'flutter_chat_ui',
-              ),
+        icon: InheritedChatTheme.of(context).theme.sendButtonIcon ??
+            Image.asset(
+              'assets/icon-send.png',
+              color: InheritedChatTheme.of(context).theme.inputTextColor,
+              package: 'flutter_chat_ui',
+            ),
         onPressed: onPressed,
         padding: EdgeInsets.zero,
         tooltip: InheritedL10n.of(context).l10n.sendButtonAccessibilityLabel,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds sendButtonMargin field to ChatTheme

### Why is it needed?

I was unable to implement design in my project without it
<img width="366" alt="image" src="https://user-images.githubusercontent.com/76782439/151430428-d3e7c723-b3f9-4b72-a42d-eae2c10fa3db.png">
Button was 'glued' to the right side
<img width="366" alt="image" src="https://user-images.githubusercontent.com/76782439/151430882-6099a100-5b7b-4166-9a5f-cf705d10e396.png">

### How to test it?

You can pass DefaultChatTheme(inputMargin: EdgeInsets.all(16)) to Chat()

### Related issues/PRs

There was no issue created for it
