### PR TITLE
feat: allow overriding of link style

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -72,6 +72,7 @@ abstract class ChatTheme {
     required this.messageInsetsVertical,
     required this.primaryColor,
     required this.receivedEmojiMessageTextStyle,
+    this.receivedMessageBodyLinkTextStyle,
     required this.receivedMessageBodyTextStyle,
     required this.receivedMessageCaptionTextStyle,
     required this.receivedMessageDocumentIconColor,
@@ -83,6 +84,7 @@ abstract class ChatTheme {
     required this.sendButtonMargin,
     required this.sendingIcon,
     required this.sentEmojiMessageTextStyle,
+    this.sentMessageBodyLinkTextStyle,
     required this.sentMessageBodyTextStyle,
     required this.sentMessageCaptionTextStyle,
     required this.sentMessageDocumentIconColor,
@@ -165,6 +167,10 @@ abstract class ChatTheme {
   /// Text style used for displaying emojis on text messages
   final TextStyle receivedEmojiMessageTextStyle;
 
+  /// Text style used for displaying link text on received text messages.
+  /// Defaults to [receivedMessageBodyTextStyle]
+  final TextStyle? receivedMessageBodyLinkTextStyle;
+
   /// Body text style used for displaying text on different types
   /// of received messages
   final TextStyle receivedMessageBodyTextStyle;
@@ -200,6 +206,10 @@ abstract class ChatTheme {
 
   /// Text style used for displaying emojis on text messages
   final TextStyle sentEmojiMessageTextStyle;
+
+  /// Text style used for displaying link text on sent text messages.
+  /// Defaults to [sentMessageBodyTextStyle]
+  final TextStyle? sentMessageBodyLinkTextStyle;
 
   /// Body text style used for displaying text on different types
   /// of sent messages
@@ -292,6 +302,7 @@ class DefaultChatTheme extends ChatTheme {
     double messageInsetsVertical = 16,
     Color primaryColor = primary,
     TextStyle receivedEmojiMessageTextStyle = const TextStyle(fontSize: 40),
+    TextStyle? receivedMessageBodyLinkTextStyle,
     TextStyle receivedMessageBodyTextStyle = const TextStyle(
       color: neutral0,
       fontSize: 16,
@@ -323,6 +334,7 @@ class DefaultChatTheme extends ChatTheme {
     EdgeInsetsGeometry? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
+    TextStyle? sentMessageBodyLinkTextStyle,
     TextStyle sentMessageBodyTextStyle = const TextStyle(
       color: neutral7,
       fontSize: 16,
@@ -387,6 +399,7 @@ class DefaultChatTheme extends ChatTheme {
           messageInsetsVertical: messageInsetsVertical,
           primaryColor: primaryColor,
           receivedEmojiMessageTextStyle: receivedEmojiMessageTextStyle,
+          receivedMessageBodyLinkTextStyle: receivedMessageBodyLinkTextStyle,
           receivedMessageBodyTextStyle: receivedMessageBodyTextStyle,
           receivedMessageCaptionTextStyle: receivedMessageCaptionTextStyle,
           receivedMessageDocumentIconColor: receivedMessageDocumentIconColor,
@@ -399,6 +412,7 @@ class DefaultChatTheme extends ChatTheme {
           sendButtonMargin: sendButtonMargin,
           sendingIcon: sendingIcon,
           sentEmojiMessageTextStyle: sentEmojiMessageTextStyle,
+          sentMessageBodyLinkTextStyle: sentMessageBodyLinkTextStyle,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,
           sentMessageCaptionTextStyle: sentMessageCaptionTextStyle,
           sentMessageDocumentIconColor: sentMessageDocumentIconColor,
@@ -466,6 +480,7 @@ class DarkChatTheme extends ChatTheme {
     double messageInsetsVertical = 16,
     Color primaryColor = primary,
     TextStyle receivedEmojiMessageTextStyle = const TextStyle(fontSize: 40),
+    TextStyle? receivedMessageBodyLinkTextStyle,
     TextStyle receivedMessageBodyTextStyle = const TextStyle(
       color: neutral7,
       fontSize: 16,
@@ -497,6 +512,7 @@ class DarkChatTheme extends ChatTheme {
     EdgeInsetsGeometry? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
+    TextStyle? sentMessageBodyLinkTextStyle,
     TextStyle sentMessageBodyTextStyle = const TextStyle(
       color: neutral7,
       fontSize: 16,
@@ -561,6 +577,7 @@ class DarkChatTheme extends ChatTheme {
           messageInsetsVertical: messageInsetsVertical,
           primaryColor: primaryColor,
           receivedEmojiMessageTextStyle: receivedEmojiMessageTextStyle,
+          receivedMessageBodyLinkTextStyle: receivedMessageBodyLinkTextStyle,
           receivedMessageBodyTextStyle: receivedMessageBodyTextStyle,
           receivedMessageCaptionTextStyle: receivedMessageCaptionTextStyle,
           receivedMessageDocumentIconColor: receivedMessageDocumentIconColor,
@@ -573,6 +590,7 @@ class DarkChatTheme extends ChatTheme {
           sendButtonMargin: sendButtonMargin,
           sendingIcon: sendingIcon,
           sentEmojiMessageTextStyle: sentEmojiMessageTextStyle,
+          sentMessageBodyLinkTextStyle: sentMessageBodyLinkTextStyle,
           sentMessageBodyTextStyle: sentMessageBodyTextStyle,
           sentMessageCaptionTextStyle: sentMessageCaptionTextStyle,
           sentMessageDocumentIconColor: sentMessageDocumentIconColor,

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -53,6 +53,9 @@ class TextMessage extends StatelessWidget {
     final bodyTextStyle = user.id == message.author.id
         ? InheritedChatTheme.of(context).theme.sentMessageBodyTextStyle
         : InheritedChatTheme.of(context).theme.receivedMessageBodyTextStyle;
+    final bodyLinkTextStyle = user.id == message.author.id
+        ? InheritedChatTheme.of(context).theme.sentMessageBodyLinkTextStyle
+        : InheritedChatTheme.of(context).theme.receivedMessageBodyLinkTextStyle;
     final linkDescriptionTextStyle = user.id == message.author.id
         ? InheritedChatTheme.of(context)
             .theme
@@ -77,7 +80,7 @@ class TextMessage extends StatelessWidget {
           .theme
           .userNameTextStyle
           .copyWith(color: color),
-      linkStyle: bodyTextStyle,
+      linkStyle: bodyLinkTextStyle ?? bodyTextStyle,
       metadataTextStyle: linkDescriptionTextStyle,
       metadataTitleStyle: linkTitleTextStyle,
       onPreviewDataFetched: _onPreviewDataFetched,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Specifying a `sentMessageBodyLinkTextStyle` or `receivedMessageBodyLinkTextStyle` in the `ChatTheme` will, optionally, override the text style used for the link preview of text messages.

### Why is it needed?

I faced an issue where I set a text style for body text in the chat theme but this style has a different decoration setting such that the underline also gets removed. Now, there is more flexibility.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
