### PR TITLE
feat: add incomplete markdown support for text messages

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -31,4 +31,18 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+
+    <!-- Required for url and mailto launching via url_launcher -->
+    <queries>
+        <!-- If your app opens https URLs -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <!-- If your app sends emails -->
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
 </manifest>

--- a/example/assets/messages.json
+++ b/example/assets/messages.json
@@ -8,6 +8,18 @@
     "createdAt": 1598438797000,
     "id": "e7a673e9-86eb-4572-936f-2882b0183cdc",
     "status": "seen",
+    "text": "## Heading\n\n**This is bold text**\n\n_This is italic text_\n\n~~Strikethrough~~\n\nInline `code`\n\n1. Lorem ipsum dolor sit amet\n2. Consectetur adipiscing elit\n3. Integer molestie lorem at massa\n\n+ Create a list by starting a line with `+`, `-`, or `*`\n+ Sub-lists are made by indenting 2 spaces:\n  - Marker character change forces new list start:\n    * Ac tristique libero volutpat at\n    + Facilisis in pretium nisl aliquet\n    - Nulla volutpat aliquam velit\n+ Very easy!",
+    "type": "text"
+  },
+  {
+    "author": {
+      "firstName": "John",
+      "id": "b4878b96-efbc-479a-8291-474ef323dec7",
+      "imageUrl": "https://avatars.githubusercontent.com/u/14123304?v=4"
+    },
+    "createdAt": 1598438797000,
+    "id": "e7a673e9-86eb-4572-936f-2882b0183cdc",
+    "status": "seen",
     "text": "https://flyer.chat",
     "type": "text"
   },

--- a/example/assets/messages.json
+++ b/example/assets/messages.json
@@ -8,7 +8,7 @@
     "createdAt": 1598438797000,
     "id": "e7a673e9-86eb-4572-936f-2882b0183cdc",
     "status": "seen",
-    "text": "**bold** _italic_ ~strikethrough~ `code`",
+    "text": "**bold** _italic_ ~strikethrough~ `code`\nhttps://link-test.com test@email.com",
     "type": "text"
   },
   {

--- a/example/assets/messages.json
+++ b/example/assets/messages.json
@@ -8,7 +8,7 @@
     "createdAt": 1598438797000,
     "id": "e7a673e9-86eb-4572-936f-2882b0183cdc",
     "status": "seen",
-    "text": "**bold** _italic_ ~strikethrough~",
+    "text": "**bold** _italic_ ~strikethrough~ `code`",
     "type": "text"
   },
   {

--- a/example/assets/messages.json
+++ b/example/assets/messages.json
@@ -8,7 +8,7 @@
     "createdAt": 1598438797000,
     "id": "e7a673e9-86eb-4572-936f-2882b0183cdc",
     "status": "seen",
-    "text": "## Heading\n\n**This is bold text**\n\n_This is italic text_\n\n~~Strikethrough~~\n\nInline `code`\n\n1. Lorem ipsum dolor sit amet\n2. Consectetur adipiscing elit\n3. Integer molestie lorem at massa\n\n+ Create a list by starting a line with `+`, `-`, or `*`\n+ Sub-lists are made by indenting 2 spaces:\n  - Marker character change forces new list start:\n    * Ac tristique libero volutpat at\n    + Facilisis in pretium nisl aliquet\n    - Nulla volutpat aliquam velit\n+ Very easy!",
+    "text": "**bold** _italic_ ~strikethrough~",
     "type": "text"
   },
   {

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -22,6 +22,11 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>https</string>
+      <string>http</string>
+    </array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -75,6 +75,7 @@ abstract class ChatTheme {
     this.receivedMessageBodyLinkTextStyle,
     required this.receivedMessageBodyTextStyle,
     this.receivedMessageBodyBoldTextStyle,
+    this.receivedMessageBodyCodeTextStyle,
     required this.receivedMessageCaptionTextStyle,
     required this.receivedMessageDocumentIconColor,
     required this.receivedMessageLinkDescriptionTextStyle,
@@ -88,6 +89,7 @@ abstract class ChatTheme {
     this.sentMessageBodyLinkTextStyle,
     required this.sentMessageBodyTextStyle,
     this.sentMessageBodyBoldTextStyle,
+    this.sentMessageBodyCodeTextStyle,
     required this.sentMessageCaptionTextStyle,
     required this.sentMessageDocumentIconColor,
     required this.sentMessageLinkDescriptionTextStyle,
@@ -181,6 +183,10 @@ abstract class ChatTheme {
   /// Default to a bold version of [receivedMessageBodyTextStyle].
   final TextStyle? receivedMessageBodyBoldTextStyle;
 
+  /// Body text style used for displaying code text on received text messages.
+  /// Defaults to a mono version of [receivedMessageBodyTextStyle].
+  final TextStyle? receivedMessageBodyCodeTextStyle;
+
   /// Caption text style used for displaying secondary info (e.g. file size)
   /// on different types of received messages
   final TextStyle receivedMessageCaptionTextStyle;
@@ -224,6 +230,10 @@ abstract class ChatTheme {
   /// Body text style used for displaying bold text on sent text messages.
   /// Defaults to a bold version of [sentMessageBodyTextStyle].
   final TextStyle? sentMessageBodyBoldTextStyle;
+
+  /// Body text style used for displaying code text on sent text messages.
+  /// Defaults to a mono version of [sentMessageBodyTextStyle].
+  final TextStyle? sentMessageBodyCodeTextStyle;
 
   /// Caption text style used for displaying secondary info (e.g. file size)
   /// on different types of sent messages

--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -74,6 +74,7 @@ abstract class ChatTheme {
     required this.receivedEmojiMessageTextStyle,
     this.receivedMessageBodyLinkTextStyle,
     required this.receivedMessageBodyTextStyle,
+    this.receivedMessageBodyBoldTextStyle,
     required this.receivedMessageCaptionTextStyle,
     required this.receivedMessageDocumentIconColor,
     required this.receivedMessageLinkDescriptionTextStyle,
@@ -86,6 +87,7 @@ abstract class ChatTheme {
     required this.sentEmojiMessageTextStyle,
     this.sentMessageBodyLinkTextStyle,
     required this.sentMessageBodyTextStyle,
+    this.sentMessageBodyBoldTextStyle,
     required this.sentMessageCaptionTextStyle,
     required this.sentMessageDocumentIconColor,
     required this.sentMessageLinkDescriptionTextStyle,
@@ -175,6 +177,10 @@ abstract class ChatTheme {
   /// of received messages
   final TextStyle receivedMessageBodyTextStyle;
 
+  /// Body text style used for displaying bold text on received text messages.
+  /// Default to a bold version of [receivedMessageBodyTextStyle].
+  final TextStyle? receivedMessageBodyBoldTextStyle;
+
   /// Caption text style used for displaying secondary info (e.g. file size)
   /// on different types of received messages
   final TextStyle receivedMessageCaptionTextStyle;
@@ -214,6 +220,10 @@ abstract class ChatTheme {
   /// Body text style used for displaying text on different types
   /// of sent messages
   final TextStyle sentMessageBodyTextStyle;
+
+  /// Body text style used for displaying bold text on sent text messages.
+  /// Defaults to a bold version of [sentMessageBodyTextStyle].
+  final TextStyle? sentMessageBodyBoldTextStyle;
 
   /// Caption text style used for displaying secondary info (e.g. file size)
   /// on different types of sent messages

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
@@ -117,6 +119,9 @@ class TextMessage extends StatelessWidget {
     final boldTextStyle = user.id == message.author.id
         ? theme.sentMessageBodyBoldTextStyle
         : theme.receivedMessageBodyBoldTextStyle;
+    final codeTextStyle = user.id == message.author.id
+        ? theme.sentMessageBodyCodeTextStyle
+        : theme.receivedMessageBodyCodeTextStyle;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -159,6 +164,16 @@ class TextMessage extends StatelessWidget {
               ),
               renderText: ({required String str, required String pattern}) {
                 return {'display': str.replaceAll('~', '')};
+              },
+            ),
+            MatchText(
+              pattern: '`(.*?)`',
+              style: codeTextStyle ??
+                  bodyTextStyle.copyWith(
+                    fontFamily: Platform.isIOS ? 'Courier' : 'monospace',
+                  ),
+              renderText: ({required String str, required String pattern}) {
+                return {'display': str.replaceAll('`', '')};
               },
             ),
           ],

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
     show LinkPreview, regexLink;
+import 'package:flutter_markdown/flutter_markdown.dart';
+
 import '../models/emoji_enlargement_behavior.dart';
 import '../util.dart';
 import 'inherited_chat_theme.dart';
@@ -105,6 +107,13 @@ class TextMessage extends StatelessWidget {
     final color =
         getUserAvatarNameColor(message.author, theme.userAvatarNameColors);
     final name = getUserName(message.author);
+    final textStyle = user.id == message.author.id
+        ? enlargeEmojis
+            ? theme.sentEmojiMessageTextStyle
+            : theme.sentMessageBodyTextStyle
+        : enlargeEmojis
+            ? theme.receivedEmojiMessageTextStyle
+            : theme.receivedMessageBodyTextStyle;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -119,16 +128,17 @@ class TextMessage extends StatelessWidget {
               style: theme.userNameTextStyle.copyWith(color: color),
             ),
           ),
-        SelectableText(
-          message.text,
-          style: user.id == message.author.id
-              ? enlargeEmojis
-                  ? theme.sentEmojiMessageTextStyle
-                  : theme.sentMessageBodyTextStyle
-              : enlargeEmojis
-                  ? theme.receivedEmojiMessageTextStyle
-                  : theme.receivedMessageBodyTextStyle,
-          textWidthBasis: TextWidthBasis.longestLine,
+        MarkdownBody(
+          data: message.text,
+          selectable: true,
+          softLineBreak: true,
+          styleSheet: MarkdownStyleSheet(
+            p: textStyle,
+            listBullet: textStyle,
+            tableBody: textStyle,
+            tableHead: textStyle.copyWith(fontWeight: FontWeight.bold),
+            tableBorder: TableBorder.all(color: Colors.white),
+          ),
         ),
       ],
     );

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -3,8 +3,9 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
-    show LinkPreview, regexLink;
+    show LinkPreview, regexEmail, regexLink;
 import 'package:flutter_parsed_text/flutter_parsed_text.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../models/emoji_enlargement_behavior.dart';
 import '../util.dart';
@@ -54,12 +55,6 @@ class TextMessage extends StatelessWidget {
     double width,
     BuildContext context,
   ) {
-    final bodyLinkTextStyle = user.id == message.author.id
-        ? InheritedChatTheme.of(context).theme.sentMessageBodyLinkTextStyle
-        : InheritedChatTheme.of(context).theme.receivedMessageBodyLinkTextStyle;
-    final bodyTextStyle = user.id == message.author.id
-        ? InheritedChatTheme.of(context).theme.sentMessageBodyTextStyle
-        : InheritedChatTheme.of(context).theme.receivedMessageBodyTextStyle;
     final linkDescriptionTextStyle = user.id == message.author.id
         ? InheritedChatTheme.of(context)
             .theme
@@ -73,18 +68,9 @@ class TextMessage extends StatelessWidget {
             .theme
             .receivedMessageLinkTitleTextStyle;
 
-    final color = getUserAvatarNameColor(message.author,
-        InheritedChatTheme.of(context).theme.userAvatarNameColors);
-    final name = getUserName(message.author);
-
     return LinkPreview(
       enableAnimation: true,
-      header: showName ? name : null,
-      headerStyle: InheritedChatTheme.of(context)
-          .theme
-          .userNameTextStyle
-          .copyWith(color: color),
-      linkStyle: bodyLinkTextStyle ?? bodyTextStyle,
+      textWidget: _textWidgetBuilder(user, context, false),
       metadataTextStyle: linkDescriptionTextStyle,
       metadataTitleStyle: linkTitleTextStyle,
       onPreviewDataFetched: _onPreviewDataFetched,
@@ -95,7 +81,6 @@ class TextMessage extends StatelessWidget {
       ),
       previewData: message.previewData,
       text: message.text,
-      textStyle: bodyTextStyle,
       width: width,
     );
   }
@@ -122,6 +107,9 @@ class TextMessage extends StatelessWidget {
     final codeTextStyle = user.id == message.author.id
         ? theme.sentMessageBodyCodeTextStyle
         : theme.receivedMessageBodyCodeTextStyle;
+    final bodyLinkTextStyle = user.id == message.author.id
+        ? InheritedChatTheme.of(context).theme.sentMessageBodyLinkTextStyle
+        : InheritedChatTheme.of(context).theme.receivedMessageBodyLinkTextStyle;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -143,7 +131,29 @@ class TextMessage extends StatelessWidget {
           regexOptions: const RegexOptions(multiLine: true, dotAll: true),
           parse: [
             MatchText(
+              pattern: regexEmail,
+              onTap: (mail) async {
+                final url = 'mailto:$mail';
+                if (await canLaunch(url)) {
+                  await launch(url);
+                }
+              },
+              style: bodyLinkTextStyle ??
+                  bodyTextStyle.copyWith(decoration: TextDecoration.underline),
+            ),
+            MatchText(
+              pattern: regexLink,
+              onTap: (url) async {
+                if (await canLaunch(url)) {
+                  await launch(url);
+                }
+              },
+              style: bodyLinkTextStyle ??
+                  bodyTextStyle.copyWith(decoration: TextDecoration.underline),
+            ),
+            MatchText(
               pattern: '(\\*\\*|\\*)(.*?)(\\*\\*|\\*)',
+              onTap: (_) {},
               style: boldTextStyle ??
                   bodyTextStyle.copyWith(fontWeight: FontWeight.bold),
               renderText: ({required String str, required String pattern}) {
@@ -152,6 +162,7 @@ class TextMessage extends StatelessWidget {
             ),
             MatchText(
               pattern: '_(.*?)_',
+              onTap: (_) {},
               style: bodyTextStyle.copyWith(fontStyle: FontStyle.italic),
               renderText: ({required String str, required String pattern}) {
                 return {'display': str.replaceAll('_', '')};
@@ -159,6 +170,7 @@ class TextMessage extends StatelessWidget {
             ),
             MatchText(
               pattern: '~(.*?)~',
+              onTap: (_) {},
               style: bodyTextStyle.copyWith(
                 decoration: TextDecoration.lineThrough,
               ),
@@ -168,6 +180,7 @@ class TextMessage extends StatelessWidget {
             ),
             MatchText(
               pattern: '`(.*?)`',
+              onTap: (_) {},
               style: codeTextStyle ??
                   bodyTextStyle.copyWith(
                     fontFamily: Platform.isIOS ? 'Courier' : 'monospace',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.17.0
   meta: ^1.7.0
   photo_view: ^0.13.0
+  url_launcher: ^6.0.20
   visibility_detector: ^0.2.2
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   equatable: ^2.0.3
   flutter_chat_types: ^3.3.1
   flutter_link_previewer: ^2.6.3
-  flutter_markdown: ^0.6.9
+  flutter_parsed_text: ^2.2.1
   intl: ^0.17.0
   meta: ^1.7.0
   photo_view: ^0.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   equatable: ^2.0.3
   flutter_chat_types: ^3.3.1
   flutter_link_previewer: ^2.6.3
+  flutter_markdown: ^0.6.9
   intl: ^0.17.0
   meta: ^1.7.0
   photo_view: ^0.13.0


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add simple markdown rendering and replace link renderer with it too. Closes #157
 
### Why is it needed?

Most modern chat apps have markdown support. Also, it is a bit cumbersome to maintain the header + text rendering logic here and in the link previewer package as well. Now, it is unified across both.

### How to test it?

I added a simple Markdown example in the example app with link and email as well.

### Open Questions / TODO

- Should there be an option to disable Markdown formatting in the `Chat` constructor?
