### PR TITLE
Allow author override through `resolveAuthor`

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -177,8 +177,7 @@ List<Object> calculateChatMessages(
       'nextMessageInGroup': nextMessageInGroup,
       'showName': notMyMessage &&
           showUserNames &&
-          showName &&
-          getUserName(message.author).isNotEmpty,
+          showName,
       'showStatus': true,
     });
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -175,9 +175,7 @@ List<Object> calculateChatMessages(
     chatMessages.insert(0, {
       'message': message,
       'nextMessageInGroup': nextMessageInGroup,
-      'showName': notMyMessage &&
-          showUserNames &&
-          showName,
+      'showName': notMyMessage && showUserNames && showName,
       'showStatus': true,
     });
 

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -59,6 +59,7 @@ class Chat extends StatefulWidget {
     required this.onSendPressed,
     this.onTextChanged,
     this.onTextFieldTap,
+    this.resolveAuthor,
     this.scrollPhysics,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.showUserAvatars = false,
@@ -196,6 +197,9 @@ class Chat extends StatefulWidget {
 
   /// See [Input.onTextFieldTap]
   final void Function()? onTextFieldTap;
+
+  /// See [Message.resolveAuthor]
+  final types.User? Function(String id)? resolveAuthor;
 
   /// See [ChatList.scrollPhysics]
   final ScrollPhysics? scrollPhysics;
@@ -385,6 +389,7 @@ class _ChatState extends State<Chat> {
           widget.onMessageTap?.call(context, tappedMessage);
         },
         onPreviewDataFetched: _onPreviewDataFetched,
+        resolveAuthor: widget.resolveAuthor,
         roundBorder: map['nextMessageInGroup'] == true,
         showAvatar: map['nextMessageInGroup'] == false,
         showName: map['showName'] == true,

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -12,6 +12,7 @@ class TextMessage extends StatelessWidget {
   /// Creates a text message widget from a [types.TextMessage] class
   const TextMessage({
     Key? key,
+    required this.author,
     required this.emojiEnlargementBehavior,
     required this.hideBackgroundOnEmojiMessages,
     required this.message,
@@ -19,6 +20,9 @@ class TextMessage extends StatelessWidget {
     required this.usePreviewData,
     required this.showName,
   }) : super(key: key);
+
+  /// Either resolved through [Message.resolveAuthor] or user from message.
+  final types.User author;
 
   /// See [Message.emojiEnlargementBehavior]
   final EmojiEnlargementBehavior emojiEnlargementBehavior;

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -110,7 +110,7 @@ class TextMessage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showName)
+        if (showName && name.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(bottom: 6),
             child: Text(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -106,8 +106,7 @@ class TextMessage extends StatelessWidget {
     bool enlargeEmojis,
   ) {
     final theme = InheritedChatTheme.of(context).theme;
-    final color =
-        getUserAvatarNameColor(author, theme.userAvatarNameColors);
+    final color = getUserAvatarNameColor(author, theme.userAvatarNameColors);
     final name = getUserName(author);
 
     return Column(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -107,8 +107,8 @@ class TextMessage extends StatelessWidget {
   ) {
     final theme = InheritedChatTheme.of(context).theme;
     final color =
-        getUserAvatarNameColor(message.author, theme.userAvatarNameColors);
-    final name = getUserName(message.author);
+        getUserAvatarNameColor(author, theme.userAvatarNameColors);
+    final name = getUserName(author);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -125,7 +125,7 @@ class TextMessage extends StatelessWidget {
           ),
         SelectableText(
           message.text,
-          style: user.id == message.author.id
+          style: user.id == author.id
               ? enlargeEmojis
                   ? theme.sentEmojiMessageTextStyle
                   : theme.sentMessageBodyTextStyle

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -70,8 +70,8 @@ class TextMessage extends StatelessWidget {
             .theme
             .receivedMessageLinkTitleTextStyle;
 
-    final color = getUserAvatarNameColor(author,
-        InheritedChatTheme.of(context).theme.userAvatarNameColors);
+    final color = getUserAvatarNameColor(
+        author, InheritedChatTheme.of(context).theme.userAvatarNameColors);
     final name = getUserName(author);
 
     return LinkPreview(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -54,25 +54,25 @@ class TextMessage extends StatelessWidget {
     double width,
     BuildContext context,
   ) {
-    final bodyTextStyle = user.id == message.author.id
+    final bodyTextStyle = user.id == author.id
         ? InheritedChatTheme.of(context).theme.sentMessageBodyTextStyle
         : InheritedChatTheme.of(context).theme.receivedMessageBodyTextStyle;
-    final linkDescriptionTextStyle = user.id == message.author.id
+    final linkDescriptionTextStyle = user.id == author.id
         ? InheritedChatTheme.of(context)
             .theme
             .sentMessageLinkDescriptionTextStyle
         : InheritedChatTheme.of(context)
             .theme
             .receivedMessageLinkDescriptionTextStyle;
-    final linkTitleTextStyle = user.id == message.author.id
+    final linkTitleTextStyle = user.id == author.id
         ? InheritedChatTheme.of(context).theme.sentMessageLinkTitleTextStyle
         : InheritedChatTheme.of(context)
             .theme
             .receivedMessageLinkTitleTextStyle;
 
-    final color = getUserAvatarNameColor(message.author,
+    final color = getUserAvatarNameColor(author,
         InheritedChatTheme.of(context).theme.userAvatarNameColors);
-    final name = getUserName(message.author);
+    final name = getUserName(author);
 
     return LinkPreview(
       enableAnimation: true,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add `resolveAuthor(String id)` method to the `Chat()` which can be used to fetch the latest user information to display in avatar and message name headers.

### Why is it needed?

Because the author currently comes from the message data, changes of profile picture or name only affect new messages (or all old messages would need to be replaced). It should be possible to optionally override user information on the top level.

### How to test it?

Add `showUserNames` and `showUserAvatars` to the Chat and specify a `resolveAuthor` function that returns newer information.

### Related issues/PRs

The other option would be specifying `nameBuilder` and `avatarBuilder` which has a wider scope and effects than this PR. If you think it would be more useful, I can also create a PR with that functionality. However, this is the smallest change necessary to solve my needs.
