### PR TITLE
feat: add onMessageVisibilityChanged handler

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -146,6 +146,10 @@ class _ChatPageState extends State<ChatPage> {
     }
   }
 
+  void _handleMessageVisibilityChanged(types.Message message, bool visible) {
+    debugPrint('${message.id} is${visible ? '' : ' not'} visible');
+  }
+
   void _handlePreviewDataFetched(
     types.TextMessage message,
     types.PreviewData previewData,
@@ -191,6 +195,7 @@ class _ChatPageState extends State<ChatPage> {
           messages: _messages,
           onAttachmentPressed: _handleAtachmentPressed,
           onMessageTap: _handleMessageTap,
+          onMessageVisibilityChanged: _handleMessageVisibilityChanged,
           onPreviewDataFetched: _handlePreviewDataFetched,
           onSendPressed: _handleSendPressed,
           user: _user,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -55,6 +55,7 @@ class Chat extends StatefulWidget {
     this.onMessageStatusLongPress,
     this.onMessageStatusTap,
     this.onMessageTap,
+    this.onMessageVisibilityChanged,
     this.onPreviewDataFetched,
     required this.onSendPressed,
     this.onTextChanged,
@@ -183,6 +184,9 @@ class Chat extends StatefulWidget {
 
   /// See [Message.onMessageTap]
   final void Function(BuildContext context, types.Message)? onMessageTap;
+
+  /// See [Message.onMessageVisibilityChanged]
+  final void Function(types.Message, bool visible)? onMessageVisibilityChanged;
 
   /// See [Message.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -384,6 +388,7 @@ class _ChatState extends State<Chat> {
 
           widget.onMessageTap?.call(context, tappedMessage);
         },
+        onMessageVisibilityChanged: widget.onMessageVisibilityChanged,
         onPreviewDataFetched: _onPreviewDataFetched,
         roundBorder: map['nextMessageInGroup'] == true,
         showAvatar: map['nextMessageInGroup'] == false,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:visibility_detector/visibility_detector.dart';
 
 import '../models/emoji_enlargement_behavior.dart';
 import '../util.dart';
@@ -30,6 +31,7 @@ class Message extends StatelessWidget {
     this.onMessageStatusLongPress,
     this.onMessageStatusTap,
     this.onMessageTap,
+    this.onMessageVisibilityChanged,
     this.onPreviewDataFetched,
     required this.roundBorder,
     required this.showAvatar,
@@ -95,6 +97,9 @@ class Message extends StatelessWidget {
 
   /// Called when user taps on any message
   final void Function(BuildContext context, types.Message)? onMessageTap;
+
+  /// Called when the message's visibility changes
+  final void Function(types.Message, bool visible)? onMessageVisibilityChanged;
 
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -323,12 +328,25 @@ class Message extends StatelessWidget {
                   onDoubleTap: () => onMessageDoubleTap?.call(context, message),
                   onLongPress: () => onMessageLongPress?.call(context, message),
                   onTap: () => onMessageTap?.call(context, message),
-                  child: _bubbleBuilder(
-                    context,
-                    _borderRadius,
-                    _currentUserIsAuthor,
-                    _enlargeEmojis,
-                  ),
+                  child: onMessageVisibilityChanged != null
+                      ? VisibilityDetector(
+                          key: Key(message.id),
+                          onVisibilityChanged: (visibilityInfo) =>
+                              onMessageVisibilityChanged!(message,
+                                  visibilityInfo.visibleFraction > 0.1),
+                          child: _bubbleBuilder(
+                            context,
+                            _borderRadius,
+                            _currentUserIsAuthor,
+                            _enlargeEmojis,
+                          ),
+                        )
+                      : _bubbleBuilder(
+                          context,
+                          _borderRadius,
+                          _currentUserIsAuthor,
+                          _enlargeEmojis,
+                        ),
                 ),
               ],
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   intl: ^0.17.0
   meta: ^1.3.0
   photo_view: ^0.13.0
+  visibility_detector: ^0.2.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/test/text_message.test.dart
+++ b/test/text_message.test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
     show LinkPreview;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 void main() {
   testWidgets('contains text message', (WidgetTester tester) async {
@@ -66,5 +67,98 @@ void main() {
 
     // Expect to find one LinkPreview
     expect(find.byType(LinkPreview), findsOneWidget);
+  });
+
+  testWidgets('triggers visibility detection', (WidgetTester tester) async {
+    // https://pub.dev/packages/visibility_detector#widget-tests
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
+    final messagesVisible = <String>{};
+    // Build the Chat widget.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Chat(
+            messages: const [
+              types.TextMessage(
+                author: types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+                id: 'id',
+                text: 'Short message',
+              ),
+              types.TextMessage(
+                author: types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+                id: 'id2',
+                text:
+                    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, '
+                    'sed do eiusmod tempor incididunt ut labore et dolore '
+                    'magna aliqua. Ut enim ad minim veniam, quis nostrud '
+                    'exercitation ullamco laboris nisi ut aliquip ex ea '
+                    'commodo consequat. Duis aute irure dolor in reprehenderit '
+                    'in voluptate velit esse cillum dolore eu fugiat nulla '
+                    'pariatur. Excepteur sint occaecat cupidatat non proident, '
+                    'sunt in culpa qui officia deserunt mollit anim id est '
+                    'laborum.',
+              ),
+              types.TextMessage(
+                author: types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+                id: 'id3',
+                text:
+                    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, '
+                    'sed do eiusmod tempor incididunt ut labore et dolore '
+                    'magna aliqua. Ut enim ad minim veniam, quis nostrud '
+                    'exercitation ullamco laboris nisi ut aliquip ex ea '
+                    'commodo consequat. Duis aute irure dolor in reprehenderit '
+                    'in voluptate velit esse cillum dolore eu fugiat nulla '
+                    'pariatur. Excepteur sint occaecat cupidatat non proident, '
+                    'sunt in culpa qui officia deserunt mollit anim id est '
+                    'laborum.',
+              ),
+              types.TextMessage(
+                author: types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+                id: 'previewId',
+                previewData: types.PreviewData(
+                  description: 'Flutter',
+                  link: 'https://flutter.dev/',
+                  title: 'Flutter',
+                ),
+                text: 'https://flutter.dev/',
+              )
+            ],
+            onSendPressed: (types.PartialText message) => {},
+            onPreviewDataFetched:
+                (types.TextMessage message, types.PreviewData previewData) =>
+                    {},
+            onMessageVisibilityChanged: (m, visible) {
+              if (visible) {
+                messagesVisible.add(m.id);
+              } else {
+                messagesVisible.remove(m.id);
+              }
+            },
+            user: const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+          ),
+        ),
+      ),
+    );
+
+    // Trigger a frame.
+    await tester.pump();
+
+    // Expect to find the first messages as visible
+    assert(messagesVisible.length == 2 &&
+        messagesVisible.containsAll(<String>{'id', 'id2'}));
+
+    // Scroll all the way up to the preview data message
+    await tester.dragUntilVisible(
+      find.byType(LinkPreview),
+      find.byType(CustomScrollView),
+      const Offset(0, 100),
+    );
+
+    // Trigger a frame.
+    await tester.pump();
+
+    // Expect to find the last message as visible
+    assert(messagesVisible.length == 2 &&
+        messagesVisible.containsAll(<String>{'id3', 'previewId'}));
   });
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added a callback for when messages become visible or scroll out of view.

### Why is it needed?

This can be used to mark messages as seen when they were actually seen. The next step will be scrolling to the last unseen message.

### How to test it?

Open the example app and look at the logger. I added a debug log message for when a message's visibility changes.

### Related issues/PRs

First part of #179 

### Question

Should I add this to the documentation or wait until I also create a PR for scroll to message?
