### PR TITLE
Add dateHeaderBuilder

### DIFF
--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -425,6 +425,10 @@ This is how it would look like
 
 Use the `customMessageBuilder` function to build whatever message you want. To store the data use a `metadata` map of the `CustomMessage`. You can have multiple different custom messages, you will need to identify them based on some property inside the `metadata` and build accordingly.
 
+## Custom date header
+
+Use the `dateHeaderBuilde` to build your custom widget for date header.
+
 ## Pagination
 
 Use `onEndReached`, `onEndReachedThreshold` and `isLastPage` parameters to control pagination. To learn more see [API reference](https://pub.dev/documentation/flutter_chat_ui/latest/flutter_chat_ui/ChatList-class.html). Here is a simple example based on a [basic usage](basic-usage):

--- a/lib/src/models/date_header.dart
+++ b/lib/src/models/date_header.dart
@@ -6,12 +6,16 @@ import 'package:meta/meta.dart';
 class DateHeader extends Equatable {
   /// Creates a date header.
   const DateHeader({
+    required this.dateTime,
     required this.text,
   });
 
   /// Equatable props
   @override
   List<Object> get props => [text];
+
+  /// DateTime
+  final DateTime dateTime;
 
   /// Text to show in a header
   final String text;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -180,7 +180,7 @@ List<Object> calculateChatMessages(
           showUserNames &&
           showName &&
           getUserName(message.author).isNotEmpty,
-      'showStatus': true,
+      'showStatus': message.showStatus,
     });
 
     if (!nextMessageInGroup) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -158,6 +158,7 @@ List<Object> calculateChatMessages(
       chatMessages.insert(
         0,
         DateHeader(
+          dateTime: DateTime.fromMillisecondsSinceEpoch(message.createdAt!),
           text: customDateHeaderText != null
               ? customDateHeaderText(
                   DateTime.fromMillisecondsSinceEpoch(message.createdAt!),
@@ -196,6 +197,7 @@ List<Object> calculateChatMessages(
       chatMessages.insert(
         0,
         DateHeader(
+          dateTime: DateTime.fromMillisecondsSinceEpoch(message.createdAt!),
           text: customDateHeaderText != null
               ? customDateHeaderText(
                   DateTime.fromMillisecondsSinceEpoch(nextMessage!.createdAt!),

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -92,7 +92,7 @@ class Chat extends StatefulWidget {
   final String Function(DateTime dateTime)? customDateHeaderText;
 
   /// Custom date header builder gives ability to customize date header widget
-  final Widget Function(DateTime dateTime)? dateHeaderBuilder;
+  final Widget Function(DateHeader dateHeader)? dateHeaderBuilder;
 
   /// See [Message.customMessageBuilder]
   final Widget Function(types.CustomMessage, {required int messageWidth})?
@@ -346,7 +346,7 @@ class _ChatState extends State<Chat> {
   Widget _messageBuilder(Object object, BoxConstraints constraints) {
     if (object is DateHeader) {
       if (widget.dateHeaderBuilder != null) {
-        return widget.dateHeaderBuilder!(object.dateTime);
+        return widget.dateHeaderBuilder!(object);
       } else {
         return Container(
           alignment: Alignment.center,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -30,6 +30,7 @@ class Chat extends StatefulWidget {
     this.bubbleBuilder,
     this.customBottomWidget,
     this.customDateHeaderText,
+    this.dateHeaderBuilder,
     this.customMessageBuilder,
     this.dateFormat,
     this.dateHeaderThreshold = 900000,
@@ -88,7 +89,10 @@ class Chat extends StatefulWidget {
   /// all default date headers, so you must handle all cases yourself, like
   /// for example today, yesterday and before. Or you can just return the same
   /// date header for any message.
-  final String Function(DateTime)? customDateHeaderText;
+  final String Function(DateTime dateTime)? customDateHeaderText;
+
+  /// Custom date header builder gives ability to customize date header widget
+  final Widget Function(DateTime dateTime)? dateHeaderBuilder;
 
   /// See [Message.customMessageBuilder]
   final Widget Function(types.CustomMessage, {required int messageWidth})?
@@ -341,14 +345,18 @@ class _ChatState extends State<Chat> {
 
   Widget _messageBuilder(Object object, BoxConstraints constraints) {
     if (object is DateHeader) {
-      return Container(
-        alignment: Alignment.center,
-        margin: widget.theme.dateDividerMargin,
-        child: Text(
-          object.text,
-          style: widget.theme.dateDividerTextStyle,
-        ),
-      );
+      if (widget.dateHeaderBuilder != null) {
+        return widget.dateHeaderBuilder!(object.dateTime);
+      } else {
+        return Container(
+          alignment: Alignment.center,
+          margin: widget.theme.dateDividerMargin,
+          child: Text(
+            object.text,
+            style: widget.theme.dateDividerTextStyle,
+          ),
+        );
+      }
     } else if (object is MessageSpacer) {
       return SizedBox(
         height: object.height,

--- a/test/util.test.dart
+++ b/test/util.test.dart
@@ -120,14 +120,14 @@ void main() {
                 'message': imageMessage,
                 'nextMessageInGroup': false,
                 'showName': false,
-                'showStatus': true
+                'showStatus': imageMessage.showStatus,
               },
               const MessageSpacer(height: 12.0, id: '1'),
               {
                 'message': message,
                 'nextMessageInGroup': false,
                 'showName': false,
-                'showStatus': true
+                'showStatus': message.showStatus
               }
             ],
             [const PreviewImage(id: '2', uri: 'https://some.image')]


### PR DESCRIPTION

### What does it do?
I've added `dateHeaderBuilder` to add ability to customize date header widget.

### Why is it needed?

For customizing date header widget. For example I wanna add shadow, border or etc. to date header.

### How to test it?

If you provide `dateHeaderBuilder` it should get called to build date header and return your custom widget. Else, default date header widget will be returned.
