### PR TITLE
Add options to open preview on title or image tap

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -60,8 +60,7 @@ class Chat extends StatefulWidget {
     required this.onSendPressed,
     this.onTextChanged,
     this.onTextFieldTap,
-    this.openOnPreviewImageTap = false,
-    this.openOnPreviewTitleTap = false,
+    this.previewTapOptions = const PreviewTapOptions(),
     this.scrollPhysics,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.showUserAvatars = false,
@@ -203,11 +202,8 @@ class Chat extends StatefulWidget {
   /// See [Input.onTextFieldTap]
   final void Function()? onTextFieldTap;
 
-  /// See [Message.openOnPreviewImageTap]
-  final bool openOnPreviewImageTap;
-
-  /// See [Message.openOnPreviewTitleTap]
-  final bool openOnPreviewTitleTap;
+  /// See [Message.previewTapOptions]
+  final PreviewTapOptions previewTapOptions;
 
   /// See [ChatList.scrollPhysics]
   final ScrollPhysics? scrollPhysics;
@@ -398,8 +394,7 @@ class _ChatState extends State<Chat> {
         },
         onMessageVisibilityChanged: widget.onMessageVisibilityChanged,
         onPreviewDataFetched: _onPreviewDataFetched,
-        openOnPreviewImageTap: widget.openOnPreviewImageTap,
-        openOnPreviewTitleTap: widget.openOnPreviewTitleTap,
+        previewTapOptions: widget.previewTapOptions,
         roundBorder: map['nextMessageInGroup'] == true,
         showAvatar: map['nextMessageInGroup'] == false,
         showName: map['showName'] == true,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -60,6 +60,8 @@ class Chat extends StatefulWidget {
     required this.onSendPressed,
     this.onTextChanged,
     this.onTextFieldTap,
+    this.openOnPreviewImageTap = false,
+    this.openOnPreviewTitleTap = false,
     this.scrollPhysics,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.showUserAvatars = false,
@@ -200,6 +202,12 @@ class Chat extends StatefulWidget {
 
   /// See [Input.onTextFieldTap]
   final void Function()? onTextFieldTap;
+
+  /// See [Message.openOnPreviewImageTap]
+  final bool openOnPreviewImageTap;
+
+  /// See [Message.openOnPreviewTitleTap]
+  final bool openOnPreviewTitleTap;
 
   /// See [ChatList.scrollPhysics]
   final ScrollPhysics? scrollPhysics;
@@ -390,6 +398,8 @@ class _ChatState extends State<Chat> {
         },
         onMessageVisibilityChanged: widget.onMessageVisibilityChanged,
         onPreviewDataFetched: _onPreviewDataFetched,
+        openOnPreviewImageTap: widget.openOnPreviewImageTap,
+        openOnPreviewTitleTap: widget.openOnPreviewTitleTap,
         roundBorder: map['nextMessageInGroup'] == true,
         showAvatar: map['nextMessageInGroup'] == false,
         showName: map['showName'] == true,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -10,6 +10,8 @@ import 'inherited_chat_theme.dart';
 import 'inherited_user.dart';
 import 'text_message.dart';
 
+export 'text_message.dart' show PreviewTapOptions;
+
 /// Base widget for all message types in the chat. Renders bubbles around
 /// messages and status. Sets maximum width for a message for
 /// a nice look on larger screens.
@@ -33,8 +35,7 @@ class Message extends StatelessWidget {
     this.onMessageTap,
     this.onMessageVisibilityChanged,
     this.onPreviewDataFetched,
-    required this.openOnPreviewImageTap,
-    required this.openOnPreviewTitleTap,
+    this.previewTapOptions = const PreviewTapOptions(),
     required this.roundBorder,
     required this.showAvatar,
     required this.showName,
@@ -107,11 +108,8 @@ class Message extends StatelessWidget {
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
 
-  /// See [TextMessage.openOnPreviewImageTap]
-  final bool openOnPreviewImageTap;
-
-  /// See [TextMessage.openOnPreviewTitleTap]
-  final bool openOnPreviewTitleTap;
+  /// See [TextMessage.previewTapOptions]
+  final PreviewTapOptions previewTapOptions;
 
   /// Rounds border of the message to visually group messages together.
   final bool roundBorder;
@@ -233,8 +231,7 @@ class Message extends StatelessWidget {
                 hideBackgroundOnEmojiMessages: hideBackgroundOnEmojiMessages,
                 message: textMessage,
                 onPreviewDataFetched: onPreviewDataFetched,
-                openOnPreviewImageTap: openOnPreviewImageTap,
-                openOnPreviewTitleTap: openOnPreviewTitleTap,
+                previewTapOptions: previewTapOptions,
                 showName: showName,
                 usePreviewData: usePreviewData,
               );

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -33,6 +33,8 @@ class Message extends StatelessWidget {
     this.onMessageTap,
     this.onMessageVisibilityChanged,
     this.onPreviewDataFetched,
+    required this.openOnPreviewImageTap,
+    required this.openOnPreviewTitleTap,
     required this.roundBorder,
     required this.showAvatar,
     required this.showName,
@@ -104,6 +106,12 @@ class Message extends StatelessWidget {
   /// See [TextMessage.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
+
+  /// See [TextMessage.openOnPreviewImageTap]
+  final bool openOnPreviewImageTap;
+
+  /// See [TextMessage.openOnPreviewTitleTap]
+  final bool openOnPreviewTitleTap;
 
   /// Rounds border of the message to visually group messages together.
   final bool roundBorder;
@@ -225,6 +233,8 @@ class Message extends StatelessWidget {
                 hideBackgroundOnEmojiMessages: hideBackgroundOnEmojiMessages,
                 message: textMessage,
                 onPreviewDataFetched: onPreviewDataFetched,
+                openOnPreviewImageTap: openOnPreviewImageTap,
+                openOnPreviewTitleTap: openOnPreviewTitleTap,
                 showName: showName,
                 usePreviewData: usePreviewData,
               );

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
     show LinkPreview, regexLink;
+
 import '../models/emoji_enlargement_behavior.dart';
 import '../util.dart';
 import 'inherited_chat_theme.dart';
@@ -15,9 +16,8 @@ class TextMessage extends StatelessWidget {
     required this.emojiEnlargementBehavior,
     required this.hideBackgroundOnEmojiMessages,
     required this.message,
-    required this.openOnPreviewImageTap,
-    required this.openOnPreviewTitleTap,
     this.onPreviewDataFetched,
+    this.previewTapOptions = const PreviewTapOptions(),
     required this.usePreviewData,
     required this.showName,
   }) : super(key: key);
@@ -35,11 +35,8 @@ class TextMessage extends StatelessWidget {
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
 
-  /// See [LinkPreview.openOnPreviewImageTap]
-  final bool openOnPreviewImageTap;
-
-  /// See [LinkPreview.openOnPreviewTitleTap]
-  final bool openOnPreviewTitleTap;
+  /// See [LinkPreview.openOnPreviewImageTap] and [LinkPreview.openOnPreviewTitleTap]
+  final PreviewTapOptions previewTapOptions;
 
   /// Show user name for the received message. Useful for a group chat.
   final bool showName;
@@ -92,8 +89,8 @@ class TextMessage extends StatelessWidget {
       metadataTextStyle: linkDescriptionTextStyle,
       metadataTitleStyle: linkTitleTextStyle,
       onPreviewDataFetched: _onPreviewDataFetched,
-      openOnPreviewImageTap: openOnPreviewImageTap,
-      openOnPreviewTitleTap: openOnPreviewTitleTap,
+      openOnPreviewImageTap: previewTapOptions.openOnImageTap,
+      openOnPreviewTitleTap: previewTapOptions.openOnTitleTap,
       padding: EdgeInsets.symmetric(
         horizontal:
             InheritedChatTheme.of(context).theme.messageInsetsHorizontal,
@@ -172,4 +169,15 @@ class TextMessage extends StatelessWidget {
       child: _textWidgetBuilder(_user, context, _enlargeEmojis),
     );
   }
+}
+
+@immutable
+class PreviewTapOptions {
+  const PreviewTapOptions({
+    this.openOnImageTap = false,
+    this.openOnTitleTap = false,
+  });
+
+  final bool openOnImageTap;
+  final bool openOnTitleTap;
 }

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -15,6 +15,8 @@ class TextMessage extends StatelessWidget {
     required this.emojiEnlargementBehavior,
     required this.hideBackgroundOnEmojiMessages,
     required this.message,
+    required this.openOnPreviewImageTap,
+    required this.openOnPreviewTitleTap,
     this.onPreviewDataFetched,
     required this.usePreviewData,
     required this.showName,
@@ -32,6 +34,12 @@ class TextMessage extends StatelessWidget {
   /// See [LinkPreview.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
+
+  /// See [LinkPreview.openOnPreviewImageTap]
+  final bool openOnPreviewImageTap;
+
+  /// See [LinkPreview.openOnPreviewTitleTap]
+  final bool openOnPreviewTitleTap;
 
   /// Show user name for the received message. Useful for a group chat.
   final bool showName;
@@ -84,6 +92,8 @@ class TextMessage extends StatelessWidget {
       metadataTextStyle: linkDescriptionTextStyle,
       metadataTitleStyle: linkTitleTextStyle,
       onPreviewDataFetched: _onPreviewDataFetched,
+      openOnPreviewImageTap: openOnPreviewImageTap,
+      openOnPreviewTitleTap: openOnPreviewTitleTap,
       padding: EdgeInsets.symmetric(
         horizontal:
             InheritedChatTheme.of(context).theme.messageInsetsHorizontal,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

You can now specify options to enable the tap-to-open behavior from yesterdays PR.

### Why is it needed?

No other way of configuring this yet.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

[Let us know if this is related to any issue/pull request.](https://github.com/flyerhq/flutter_link_previewer/pull/39)
