### PR TITLE
A new SendButtonVisibilityMode

### DIFF
--- a/lib/src/models/send_button_visibility_mode.dart
+++ b/lib/src/models/send_button_visibility_mode.dart
@@ -6,4 +6,7 @@ enum SendButtonVisibilityMode {
 
   /// The [SendButton] will only appear when the [TextField] is not empty.
   editing,
+
+  /// Always hide the [SendButton] regardless of the [TextField] state.
+  hided,
 }

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -71,8 +71,6 @@ class _InputState extends State<Input> {
     if (widget.sendButtonVisibilityMode == SendButtonVisibilityMode.editing) {
       _sendButtonVisible = _textController.text.trim() != '';
       _textController.addListener(_handleTextControllerChange);
-    } else {
-      _sendButtonVisible = true;
     }
   }
 
@@ -109,6 +107,11 @@ class _InputState extends State<Input> {
   }
 
   Widget _inputBuilder() {
+
+    if (widget.sendButtonVisibilityMode != SendButtonVisibilityMode.editing) {
+      _sendButtonVisible = widget.sendButtonVisibilityMode == SendButtonVisibilityMode.always;
+    }
+
     final _query = MediaQuery.of(context);
     final _safeAreaInsets = kIsWeb
         ? EdgeInsets.zero

--- a/test/input.test.dart
+++ b/test/input.test.dart
@@ -30,6 +30,30 @@ void main() {
     });
 
     testWidgets(
+      'The SendButton should always be invisible when sendButtonVisibilityMode is set to SendButtonVisibilityMode.hided',
+      (WidgetTester tester) async {
+        // Build the Chat widget.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Chat(
+                messages: const [],
+                onSendPressed: (types.PartialText message) {},
+                sendButtonVisibilityMode: SendButtonVisibilityMode.hided,
+                user:
+                const types.User(id: '06c33e8b-e835-4736-80f4-63f44b66666c'),
+              ),
+            ),
+          ),
+        );
+        // Trigger a frame.
+        await tester.pump();
+
+        // The SendButton should not exist in the widget tree.
+        expect(find.byType(SendButton), findsNothing);
+    });
+
+    testWidgets(
         'The SendButton should be invisible only when sendButtonVisibilityMode is not specified and the TextField is empty',
         (WidgetTester tester) async {
       // Build the Chat widget.


### PR DESCRIPTION
### What does it do?

Added a new option of SendButtonVisibilityMode, the `hided`.

### Why is it needed?

Enable the control of visibility, necessary in cases like lost connection of chat or other validations/conditions.

### How to test it?

Just run the tests.
