### PR TITLE
allow using custom avatar builder to always fetch newest profile

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -67,7 +67,7 @@ class Chat extends StatefulWidget {
     this.textMessageBuilder,
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
-    this.userBuilder,
+    this.avatarBuilder,
     this.usePreviewData = true,
     required this.user,
   }) : super(key: key);
@@ -213,7 +213,7 @@ class Chat extends StatefulWidget {
 
   /// This is to allow custom user builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? userBuilder;
+  final Widget Function(String userId)? avatarBuilder;
 
   /// Show user names for received messages. Useful for a group chat. Will be
   /// shown only on text messages.
@@ -402,7 +402,7 @@ class _ChatState extends State<Chat> {
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
         usePreviewData: widget.usePreviewData,
-        userBuilder: widget.userBuilder,
+        avatarBuilder: widget.avatarBuilder,
       );
     }
   }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -67,6 +67,7 @@ class Chat extends StatefulWidget {
     this.textMessageBuilder,
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
+    this.userBuilder,
     this.usePreviewData = true,
     required this.user,
   }) : super(key: key);
@@ -209,6 +210,10 @@ class Chat extends StatefulWidget {
 
   /// See [Message.showUserAvatars]
   final bool showUserAvatars;
+
+  /// This is to allow custom user builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? userBuilder;
 
   /// Show user names for received messages. Useful for a group chat. Will be
   /// shown only on text messages.
@@ -397,6 +402,7 @@ class _ChatState extends State<Chat> {
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
         usePreviewData: widget.usePreviewData,
+        userBuilder: widget.userBuilder,
       );
     }
   }

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -39,7 +39,7 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
-    this.userBuilder,
+    this.avatarBuilder,
     required this.usePreviewData,
   }) : super(key: key);
 
@@ -123,7 +123,7 @@ class Message extends StatelessWidget {
 
   /// This is to allow custom user builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? userBuilder;
+  final Widget Function(String userId)? avatarBuilder;
 
   /// Build a text message inside predefined bubble.
   final Widget Function(
@@ -144,8 +144,8 @@ class Message extends StatelessWidget {
     final initials = getUserInitials(message.author);
 
     return showAvatar
-        ? userBuilder != null
-            ? userBuilder!(message.author.id)
+        ? avatarBuilder != null
+            ? avatarBuilder!(message.author.id)
             : Container(
                 margin: const EdgeInsets.only(right: 8),
                 child: GestureDetector(

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -39,6 +39,7 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
+    this.userBuilder,
     required this.usePreviewData,
   }) : super(key: key);
 
@@ -120,6 +121,10 @@ class Message extends StatelessWidget {
   /// Show user avatars for received messages. Useful for a group chat.
   final bool showUserAvatars;
 
+  /// This is to allow custom user builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? userBuilder;
+
   /// Build a text message inside predefined bubble.
   final Widget Function(
     types.TextMessage, {
@@ -139,30 +144,33 @@ class Message extends StatelessWidget {
     final initials = getUserInitials(message.author);
 
     return showAvatar
-        ? Container(
-            margin: const EdgeInsets.only(right: 8),
-            child: GestureDetector(
-              onTap: () => onAvatarTap?.call(message.author),
-              child: CircleAvatar(
-                backgroundColor: hasImage
-                    ? InheritedChatTheme.of(context)
-                        .theme
-                        .userAvatarImageBackgroundColor
-                    : color,
-                backgroundImage:
-                    hasImage ? NetworkImage(message.author.imageUrl!) : null,
-                radius: 16,
-                child: !hasImage
-                    ? Text(
-                        initials,
-                        style: InheritedChatTheme.of(context)
+        ? userBuilder != null
+            ? userBuilder!(message.author.id)
+            : Container(
+                margin: const EdgeInsets.only(right: 8),
+                child: GestureDetector(
+                  onTap: () => onAvatarTap?.call(message.author),
+                  child: CircleAvatar(
+                    backgroundColor: hasImage
+                        ? InheritedChatTheme.of(context)
                             .theme
-                            .userAvatarTextStyle,
-                      )
-                    : null,
-              ),
-            ),
-          )
+                            .userAvatarImageBackgroundColor
+                        : color,
+                    backgroundImage: hasImage
+                        ? NetworkImage(message.author.imageUrl!)
+                        : null,
+                    radius: 16,
+                    child: !hasImage
+                        ? Text(
+                            initials,
+                            style: InheritedChatTheme.of(context)
+                                .theme
+                                .userAvatarTextStyle,
+                          )
+                        : null,
+                  ),
+                ),
+              )
         : const SizedBox(width: 40);
   }
 


### PR DESCRIPTION
What does it do?
Adding avatar builder that can be future builder which can be used to fetch the latest user information to display in avatar.

Why is it needed?
Because the author currently comes from the message data, changes of profile picture only affect new messages (or all old messages would need to be replaced). It should be possible to optionally override Avatar information on the top level. 

How to test it?
add param avatarBuilder that accept Widget Function(String userId), with this we can access the user id for that message and use our own widget to fetch user avatar

Related issues/PRs
https://github.com/flyerhq/flutter_chat_ui/pull/207
This PR not includes user name builder, because i believe we can already override using existing builder.