### PR TITLE
Respecting margin for emoji-only messages

### DIFF
--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -154,9 +154,7 @@ class TextMessage extends StatelessWidget {
 
     return Container(
       margin: EdgeInsets.symmetric(
-        horizontal: _enlargeEmojis && hideBackgroundOnEmojiMessages
-            ? 0.0
-            : _theme.messageInsetsHorizontal,
+        horizontal: _theme.messageInsetsHorizontal,
         vertical: _theme.messageInsetsVertical,
       ),
       child: _textWidgetBuilder(_user, context, _enlargeEmojis),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

It's a minor change, regarding the horizontal margin in text messages.

### Why is it needed?

Text messages containing just 1 or more emoji's did not respect any horizontal margin set. It's always defaulted to `0.0`. Hence these kind of messages look different from all the other messages. 

### How to test it?

Create a message with just one or more emoji characters.

### Related issues/PRs

It fixes issue #216.