### PR TITLE
feat: increase send button tap size

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -104,7 +104,7 @@ abstract class ChatTheme {
   final Color backgroundColor;
 
   /// Margin around date dividers
-  final EdgeInsetsGeometry dateDividerMargin;
+  final EdgeInsets dateDividerMargin;
 
   /// Text style of the date dividers
   final TextStyle dateDividerTextStyle;
@@ -134,10 +134,10 @@ abstract class ChatTheme {
   final Decoration? inputContainerDecoration;
 
   /// Inner insets of the bottom bar where text field is
-  final EdgeInsetsGeometry inputPadding;
+  final EdgeInsets inputPadding;
 
   /// Outer insets of the bottom bar where text field is
-  final EdgeInsetsGeometry inputMargin;
+  final EdgeInsets inputMargin;
 
   /// Color of the text field's text and attachment/send buttons
   final Color inputTextColor;
@@ -199,7 +199,7 @@ abstract class ChatTheme {
   final Widget? sendButtonIcon;
 
   /// Margin of send button
-  final EdgeInsetsGeometry? sendButtonMargin;
+  final EdgeInsets? sendButtonMargin;
 
   /// Icon for message's `sending` status. For the best look use size of 10.
   final Widget? sendingIcon;
@@ -230,7 +230,7 @@ abstract class ChatTheme {
   final TextStyle sentMessageLinkTitleTextStyle;
 
   /// Padding around status icons
-  final EdgeInsetsGeometry statusIconPadding;
+  final EdgeInsets statusIconPadding;
 
   /// Color used as a background for user avatar if an image is provided.
   /// Visible if the image has some transparent parts.
@@ -258,7 +258,7 @@ class DefaultChatTheme extends ChatTheme {
   const DefaultChatTheme({
     Widget? attachmentButtonIcon,
     Color backgroundColor = neutral7,
-    EdgeInsetsGeometry dateDividerMargin = const EdgeInsets.only(
+    EdgeInsets dateDividerMargin = const EdgeInsets.only(
       bottom: 32,
       top: 16,
     ),
@@ -283,8 +283,8 @@ class DefaultChatTheme extends ChatTheme {
       top: Radius.circular(20),
     ),
     Decoration? inputContainerDecoration,
-    EdgeInsetsGeometry inputPadding = const EdgeInsets.fromLTRB(24, 20, 24, 20),
-    EdgeInsetsGeometry inputMargin = EdgeInsets.zero,
+    EdgeInsets inputPadding = const EdgeInsets.fromLTRB(24, 20, 24, 20),
+    EdgeInsets inputMargin = EdgeInsets.zero,
     Color inputTextColor = neutral7,
     Color? inputTextCursorColor,
     InputDecoration inputTextDecoration = const InputDecoration(
@@ -331,7 +331,7 @@ class DefaultChatTheme extends ChatTheme {
     Color secondaryColor = secondary,
     Widget? seenIcon,
     Widget? sendButtonIcon,
-    EdgeInsetsGeometry? sendButtonMargin,
+    EdgeInsets? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     TextStyle? sentMessageBodyLinkTextStyle,
@@ -360,8 +360,7 @@ class DefaultChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.375,
     ),
-    EdgeInsetsGeometry statusIconPadding =
-        const EdgeInsets.symmetric(horizontal: 4),
+    EdgeInsets statusIconPadding = const EdgeInsets.symmetric(horizontal: 4),
     Color userAvatarImageBackgroundColor = Colors.transparent,
     List<Color> userAvatarNameColors = colors,
     TextStyle userAvatarTextStyle = const TextStyle(
@@ -436,7 +435,7 @@ class DarkChatTheme extends ChatTheme {
   const DarkChatTheme({
     Widget? attachmentButtonIcon,
     Color backgroundColor = dark,
-    EdgeInsetsGeometry dateDividerMargin = const EdgeInsets.only(
+    EdgeInsets dateDividerMargin = const EdgeInsets.only(
       bottom: 32,
       top: 16,
     ),
@@ -461,8 +460,8 @@ class DarkChatTheme extends ChatTheme {
       top: Radius.circular(20),
     ),
     Decoration? inputContainerDecoration,
-    EdgeInsetsGeometry inputPadding = const EdgeInsets.fromLTRB(24, 20, 24, 20),
-    EdgeInsetsGeometry inputMargin = EdgeInsets.zero,
+    EdgeInsets inputPadding = const EdgeInsets.fromLTRB(24, 20, 24, 20),
+    EdgeInsets inputMargin = EdgeInsets.zero,
     Color inputTextColor = neutral7,
     Color? inputTextCursorColor,
     InputDecoration inputTextDecoration = const InputDecoration(
@@ -509,7 +508,7 @@ class DarkChatTheme extends ChatTheme {
     Color secondaryColor = secondaryDark,
     Widget? seenIcon,
     Widget? sendButtonIcon,
-    EdgeInsetsGeometry? sendButtonMargin,
+    EdgeInsets? sendButtonMargin,
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     TextStyle? sentMessageBodyLinkTextStyle,
@@ -538,8 +537,7 @@ class DarkChatTheme extends ChatTheme {
       fontWeight: FontWeight.w800,
       height: 1.375,
     ),
-    EdgeInsetsGeometry statusIconPadding =
-        const EdgeInsets.symmetric(horizontal: 4),
+    EdgeInsets statusIconPadding = const EdgeInsets.symmetric(horizontal: 4),
     Color userAvatarImageBackgroundColor = Colors.transparent,
     List<Color> userAvatarNameColors = colors,
     TextStyle userAvatarTextStyle = const TextStyle(

--- a/lib/src/widgets/attachment_button.dart
+++ b/lib/src/widgets/attachment_button.dart
@@ -8,9 +8,13 @@ class AttachmentButton extends StatelessWidget {
   /// Creates attachment button widget
   const AttachmentButton({
     Key? key,
+    this.isLoading = false,
     this.onPressed,
     this.padding = EdgeInsets.zero,
   }) : super(key: key);
+
+  /// Show a loading spinner instead of the icon
+  final bool isLoading;
 
   /// Callback for attachment button tap event
   final void Function()? onPressed;
@@ -22,13 +26,25 @@ class AttachmentButton extends StatelessWidget {
   Widget build(BuildContext context) => IconButton(
         splashRadius: 24,
         constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
-        icon: InheritedChatTheme.of(context).theme.attachmentButtonIcon ??
-            Image.asset(
-              'assets/icon-attachment.png',
-              color: InheritedChatTheme.of(context).theme.inputTextColor,
-              package: 'flutter_chat_ui',
-            ),
-        onPressed: onPressed,
+        icon: isLoading
+            ? SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(
+                  backgroundColor: Colors.transparent,
+                  strokeWidth: 1.5,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    InheritedChatTheme.of(context).theme.inputTextColor,
+                  ),
+                ),
+              )
+            : InheritedChatTheme.of(context).theme.attachmentButtonIcon ??
+                Image.asset(
+                  'assets/icon-attachment.png',
+                  color: InheritedChatTheme.of(context).theme.inputTextColor,
+                  package: 'flutter_chat_ui',
+                ),
+        onPressed: isLoading ? null : onPressed,
         padding: padding,
         tooltip:
             InheritedL10n.of(context).l10n.attachmentButtonAccessibilityLabel,

--- a/lib/src/widgets/attachment_button.dart
+++ b/lib/src/widgets/attachment_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'inherited_chat_theme.dart';
 import 'inherited_l10n.dart';
 
@@ -8,30 +9,28 @@ class AttachmentButton extends StatelessWidget {
   const AttachmentButton({
     Key? key,
     this.onPressed,
+    this.padding = EdgeInsets.zero,
   }) : super(key: key);
 
   /// Callback for attachment button tap event
   final void Function()? onPressed;
 
+  /// Padding around the icon button
+  final EdgeInsets padding;
+
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 24,
-      margin: const EdgeInsets.only(right: 16),
-      width: 24,
-      child: IconButton(
-        icon: InheritedChatTheme.of(context).theme.attachmentButtonIcon != null
-            ? InheritedChatTheme.of(context).theme.attachmentButtonIcon!
-            : Image.asset(
-                'assets/icon-attachment.png',
-                color: InheritedChatTheme.of(context).theme.inputTextColor,
-                package: 'flutter_chat_ui',
-              ),
+  Widget build(BuildContext context) => IconButton(
+        splashRadius: 24,
+        constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+        icon: InheritedChatTheme.of(context).theme.attachmentButtonIcon ??
+            Image.asset(
+              'assets/icon-attachment.png',
+              color: InheritedChatTheme.of(context).theme.inputTextColor,
+              package: 'flutter_chat_ui',
+            ),
         onPressed: onPressed,
-        padding: EdgeInsets.zero,
+        padding: padding,
         tooltip:
             InheritedL10n.of(context).l10n.attachmentButtonAccessibilityLabel,
-      ),
-    );
-  }
+      );
 }

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
 import '../models/send_button_visibility_mode.dart';
 import 'attachment_button.dart';
 import 'inherited_chat_theme.dart';
@@ -118,6 +119,10 @@ class _InputState extends State<Input> {
             _query.padding.right,
             _query.viewInsets.bottom + _query.padding.bottom,
           );
+    final _textPadding =
+        InheritedChatTheme.of(context).theme.inputPadding.copyWith(right: 0);
+    final _buttonPadding =
+        InheritedChatTheme.of(context).theme.inputPadding.copyWith(left: 12);
 
     return Focus(
       autofocus: true,
@@ -129,56 +134,57 @@ class _InputState extends State<Input> {
           child: Container(
             decoration:
                 InheritedChatTheme.of(context).theme.inputContainerDecoration,
-            padding: InheritedChatTheme.of(context)
-                .theme
-                .inputPadding
-                .add(_safeAreaInsets),
+            padding: _safeAreaInsets,
             child: Row(
               children: [
                 if (widget.onAttachmentPressed != null) _leftWidgetBuilder(),
                 Expanded(
-                  child: TextField(
-                    controller: _textController,
-                    cursorColor: InheritedChatTheme.of(context)
-                        .theme
-                        .inputTextCursorColor,
-                    decoration: InheritedChatTheme.of(context)
-                        .theme
-                        .inputTextDecoration
-                        .copyWith(
-                          hintStyle: InheritedChatTheme.of(context)
-                              .theme
-                              .inputTextStyle
-                              .copyWith(
-                                color: InheritedChatTheme.of(context)
-                                    .theme
-                                    .inputTextColor
-                                    .withOpacity(0.5),
-                              ),
-                          hintText:
-                              InheritedL10n.of(context).l10n.inputPlaceholder,
-                        ),
-                    focusNode: _inputFocusNode,
-                    keyboardType: TextInputType.multiline,
-                    maxLines: 5,
-                    minLines: 1,
-                    onChanged: widget.onTextChanged,
-                    onTap: widget.onTextFieldTap,
-                    style: InheritedChatTheme.of(context)
-                        .theme
-                        .inputTextStyle
-                        .copyWith(
-                          color: InheritedChatTheme.of(context)
-                              .theme
-                              .inputTextColor,
-                        ),
-                    textCapitalization: TextCapitalization.sentences,
+                  child: Padding(
+                    padding: _textPadding,
+                    child: TextField(
+                      controller: _textController,
+                      cursorColor: InheritedChatTheme.of(context)
+                          .theme
+                          .inputTextCursorColor,
+                      decoration: InheritedChatTheme.of(context)
+                          .theme
+                          .inputTextDecoration
+                          .copyWith(
+                            hintStyle: InheritedChatTheme.of(context)
+                                .theme
+                                .inputTextStyle
+                                .copyWith(
+                                  color: InheritedChatTheme.of(context)
+                                      .theme
+                                      .inputTextColor
+                                      .withOpacity(0.5),
+                                ),
+                            hintText:
+                                InheritedL10n.of(context).l10n.inputPlaceholder,
+                          ),
+                      focusNode: _inputFocusNode,
+                      keyboardType: TextInputType.multiline,
+                      maxLines: 5,
+                      minLines: 1,
+                      onChanged: widget.onTextChanged,
+                      onTap: widget.onTextFieldTap,
+                      style: InheritedChatTheme.of(context)
+                          .theme
+                          .inputTextStyle
+                          .copyWith(
+                            color: InheritedChatTheme.of(context)
+                                .theme
+                                .inputTextColor,
+                          ),
+                      textCapitalization: TextCapitalization.sentences,
+                    ),
                   ),
                 ),
                 Visibility(
                   visible: _sendButtonVisible,
                   child: SendButton(
                     onPressed: _handleSendPressed,
+                    padding: _buttonPadding,
                   ),
                 ),
               ],

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -149,7 +149,11 @@ class _InputState extends State<Input> {
             child: Row(
               children: [
                 if (widget.onAttachmentPressed != null) ...[
-                  _leftWidgetBuilder(_attachmentButtonPadding),
+                  AttachmentButton(
+                    isLoading: widget.isAttachmentUploading ?? false,
+                    onPressed: widget.onAttachmentPressed,
+                    padding: _attachmentButtonPadding,
+                  ),
                   const SizedBox(width: 16),
                 ],
                 Expanded(
@@ -207,28 +211,6 @@ class _InputState extends State<Input> {
         ),
       ),
     );
-  }
-
-  Widget _leftWidgetBuilder(EdgeInsets attachmentButtonPadding) {
-    if (widget.isAttachmentUploading == true) {
-      return Container(
-        padding: attachmentButtonPadding,
-        height: 24,
-        width: 24,
-        child: CircularProgressIndicator(
-          backgroundColor: Colors.transparent,
-          strokeWidth: 1.5,
-          valueColor: AlwaysStoppedAnimation<Color>(
-            InheritedChatTheme.of(context).theme.inputTextColor,
-          ),
-        ),
-      );
-    } else {
-      return AttachmentButton(
-        onPressed: widget.onAttachmentPressed,
-        padding: attachmentButtonPadding,
-      );
-    }
   }
 
   @override

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -119,10 +119,21 @@ class _InputState extends State<Input> {
             _query.padding.right,
             _query.viewInsets.bottom + _query.padding.bottom,
           );
-    final _textPadding =
-        InheritedChatTheme.of(context).theme.inputPadding.copyWith(right: 0);
-    final _buttonPadding =
-        InheritedChatTheme.of(context).theme.inputPadding.copyWith(left: 12);
+    final _textPadding = InheritedChatTheme.of(context)
+        .theme
+        .inputPadding
+        .copyWith(
+              right: 0,
+              left: widget.onAttachmentPressed != null ? 0 : null,
+            );
+    final _attachmentButtonPadding = InheritedChatTheme.of(context)
+        .theme
+        .inputPadding
+        .copyWith(right: 0);
+    final _sendButtonPadding = InheritedChatTheme.of(context)
+        .theme
+        .inputPadding
+        .copyWith(left: 12);
 
     return Focus(
       autofocus: true,
@@ -137,7 +148,10 @@ class _InputState extends State<Input> {
             padding: _safeAreaInsets,
             child: Row(
               children: [
-                if (widget.onAttachmentPressed != null) _leftWidgetBuilder(),
+                if (widget.onAttachmentPressed != null) ...[
+                  _leftWidgetBuilder(_attachmentButtonPadding),
+                  const SizedBox(width: 16),
+                ],
                 Expanded(
                   child: Padding(
                     padding: _textPadding,
@@ -184,7 +198,7 @@ class _InputState extends State<Input> {
                   visible: _sendButtonVisible,
                   child: SendButton(
                     onPressed: _handleSendPressed,
-                    padding: _buttonPadding,
+                    padding: _sendButtonPadding,
                   ),
                 ),
               ],
@@ -195,11 +209,11 @@ class _InputState extends State<Input> {
     );
   }
 
-  Widget _leftWidgetBuilder() {
+  Widget _leftWidgetBuilder(EdgeInsets attachmentButtonPadding) {
     if (widget.isAttachmentUploading == true) {
       return Container(
+        padding: attachmentButtonPadding,
         height: 24,
-        margin: const EdgeInsets.only(right: 16),
         width: 24,
         child: CircularProgressIndicator(
           backgroundColor: Colors.transparent,
@@ -210,7 +224,10 @@ class _InputState extends State<Input> {
         ),
       );
     } else {
-      return AttachmentButton(onPressed: widget.onAttachmentPressed);
+      return AttachmentButton(
+        onPressed: widget.onAttachmentPressed,
+        padding: attachmentButtonPadding,
+      );
     }
   }
 

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -119,21 +119,15 @@ class _InputState extends State<Input> {
             _query.padding.right,
             _query.viewInsets.bottom + _query.padding.bottom,
           );
-    final _textPadding = InheritedChatTheme.of(context)
-        .theme
-        .inputPadding
-        .copyWith(
+    final _textPadding =
+        InheritedChatTheme.of(context).theme.inputPadding.copyWith(
               right: 0,
               left: widget.onAttachmentPressed != null ? 0 : null,
             );
-    final _attachmentButtonPadding = InheritedChatTheme.of(context)
-        .theme
-        .inputPadding
-        .copyWith(right: 0);
-    final _sendButtonPadding = InheritedChatTheme.of(context)
-        .theme
-        .inputPadding
-        .copyWith(left: 12);
+    final _attachmentButtonPadding =
+        InheritedChatTheme.of(context).theme.inputPadding.copyWith(right: 0);
+    final _sendButtonPadding =
+        InheritedChatTheme.of(context).theme.inputPadding.copyWith(left: 12);
 
     return Focus(
       autofocus: true,

--- a/lib/src/widgets/send_button.dart
+++ b/lib/src/widgets/send_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'inherited_chat_theme.dart';
 import 'inherited_l10n.dart';
 
@@ -8,19 +9,23 @@ class SendButton extends StatelessWidget {
   const SendButton({
     Key? key,
     required this.onPressed,
+    this.padding = EdgeInsets.zero,
   }) : super(key: key);
 
   /// Callback for send button tap event
   final void Function() onPressed;
 
+  /// Padding around the icon button
+  final EdgeInsets padding;
+
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 24,
       margin: InheritedChatTheme.of(context).theme.sendButtonMargin ??
           const EdgeInsets.only(left: 16),
-      width: 24,
       child: IconButton(
+        splashRadius: 24,
+        constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
         icon: InheritedChatTheme.of(context).theme.sendButtonIcon ??
             Image.asset(
               'assets/icon-send.png',
@@ -28,7 +33,7 @@ class SendButton extends StatelessWidget {
               package: 'flutter_chat_ui',
             ),
         onPressed: onPressed,
-        padding: EdgeInsets.zero,
+        padding: padding,
         tooltip: InheritedL10n.of(context).l10n.sendButtonAccessibilityLabel,
       ),
     );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Increase the tap target size of the send icon. For this, I had to apply the padding a bit differently and convert EdgeInsetsGeomtry to EdgeInset for this (which is anyways used most of the times).

Also, keep in mind that I extended the padding on the left of the send button by 12pt. Should we reduce the margin on the left side of the send button by that amount? It would be weird to not allow tapping to the left of the button.

### Why is it needed?

Before, the send icon could only be tapped in a 24pt box. This can sometimes be rather fiddley and annoying, to some degree.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
