### PR TITLE
feat: add scroll controller as a parameter

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -73,6 +73,7 @@ class Chat extends StatefulWidget {
     this.timeFormat,
     this.usePreviewData = true,
     required this.user,
+    this.scrollController,
   }) : super(key: key);
 
   /// See [Message.bubbleBuilder]
@@ -251,6 +252,9 @@ class Chat extends StatefulWidget {
 
   /// See [InheritedUser.user]
   final types.User user;
+
+  /// See [ChatList.scrollController]
+  final ScrollController? scrollController;
 
   @override
   _ChatState createState() => _ChatState();
@@ -485,6 +489,7 @@ class _ChatState extends State<Chat> {
                                   onEndReachedThreshold:
                                       widget.onEndReachedThreshold,
                                   scrollPhysics: widget.scrollPhysics,
+                                  scrollController: widget.scrollController,
                                 ),
                               ),
                             ),

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -8,15 +8,16 @@ import 'inherited_user.dart';
 /// Animated list which handles automatic animations and pagination
 class ChatList extends StatefulWidget {
   /// Creates a chat list widget
-  const ChatList({
-    Key? key,
-    this.isLastPage,
-    required this.itemBuilder,
-    required this.items,
-    this.onEndReached,
-    this.onEndReachedThreshold,
-    this.scrollPhysics,
-  }) : super(key: key);
+  const ChatList(
+      {Key? key,
+      this.isLastPage,
+      required this.itemBuilder,
+      required this.items,
+      this.onEndReached,
+      this.onEndReachedThreshold,
+      this.scrollPhysics,
+      this.scrollController})
+      : super(key: key);
 
   /// Used for pagination (infinite scroll) together with [onEndReached].
   /// When true, indicates that there are no more pages to load and
@@ -43,6 +44,9 @@ class ChatList extends StatefulWidget {
   /// Determines the physics of the scroll view
   final ScrollPhysics? scrollPhysics;
 
+  /// Used to control the chat list scroll view
+  final ScrollController? scrollController;
+
   @override
   _ChatListState createState() => _ChatListState();
 }
@@ -54,7 +58,7 @@ class _ChatListState extends State<ChatList>
   final GlobalKey<SliverAnimatedListState> _listKey =
       GlobalKey<SliverAnimatedListState>();
   late List<Object> _oldData = List.from(widget.items);
-  final _scrollController = ScrollController();
+  late ScrollController _scrollController;
 
   late final AnimationController _controller = AnimationController(vsync: this);
 
@@ -66,7 +70,7 @@ class _ChatListState extends State<ChatList>
   @override
   void initState() {
     super.initState();
-
+    _scrollController = widget.scrollController ?? ScrollController();
     didUpdateWidget(widget);
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Scrollcontroller can now be passed to the Chat.
this would add the flexibility of controlling the chat scroll view outside the widget

### Why is it needed?

To be able to control the scroll view. ex: a widget to scroll to the bottom of the chat.
I have a widget that is shown whenever a new message is received and the user is scrolled up in the chat, upon tapping the widget it scrolls to the end of the list.

### How to test it?

Create a `scrollController` and pass it to the chat widget.


