### PR TITLE
Make attachment button margin configurable

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -50,6 +50,7 @@ abstract class ChatTheme {
   /// Creates a new chat theme based on provided colors and text styles.
   const ChatTheme({
     required this.attachmentButtonIcon,
+    required this.attachmentButtonMargin,
     required this.backgroundColor,
     required this.dateDividerMargin,
     required this.dateDividerTextStyle,
@@ -103,6 +104,9 @@ abstract class ChatTheme {
 
   /// Icon for select attachment button
   final Widget? attachmentButtonIcon;
+
+  /// Margin of attachment button
+  final EdgeInsets? attachmentButtonMargin;
 
   /// Used as a background color of a chat widget
   final Color backgroundColor;
@@ -277,6 +281,7 @@ class DefaultChatTheme extends ChatTheme {
   /// which extends [ChatTheme]
   const DefaultChatTheme({
     Widget? attachmentButtonIcon,
+    EdgeInsets? attachmentButtonMargin,
     Color backgroundColor = neutral7,
     EdgeInsets dateDividerMargin = const EdgeInsets.only(
       bottom: 32,
@@ -400,6 +405,7 @@ class DefaultChatTheme extends ChatTheme {
     ),
   }) : super(
           attachmentButtonIcon: attachmentButtonIcon,
+          attachmentButtonMargin: attachmentButtonMargin,
           backgroundColor: backgroundColor,
           dateDividerMargin: dateDividerMargin,
           dateDividerTextStyle: dateDividerTextStyle,
@@ -462,6 +468,7 @@ class DarkChatTheme extends ChatTheme {
   /// which extends [ChatTheme]
   const DarkChatTheme({
     Widget? attachmentButtonIcon,
+    EdgeInsets? attachmentButtonMargin,
     Color backgroundColor = dark,
     EdgeInsets dateDividerMargin = const EdgeInsets.only(
       bottom: 32,
@@ -585,6 +592,7 @@ class DarkChatTheme extends ChatTheme {
     ),
   }) : super(
           attachmentButtonIcon: attachmentButtonIcon,
+          attachmentButtonMargin: attachmentButtonMargin,
           backgroundColor: backgroundColor,
           dateDividerMargin: dateDividerMargin,
           dateDividerTextStyle: dateDividerTextStyle,

--- a/lib/src/widgets/attachment_button.dart
+++ b/lib/src/widgets/attachment_button.dart
@@ -24,31 +24,35 @@ class AttachmentButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return IconButton(
-      constraints: const BoxConstraints(minHeight: 24, minWidth: 24),
-      icon: isLoading
-          ? SizedBox(
-              height: 20,
-              width: 20,
-              child: CircularProgressIndicator(
-                backgroundColor: Colors.transparent,
-                strokeWidth: 1.5,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  InheritedChatTheme.of(context).theme.inputTextColor,
+    return Container(
+      margin: InheritedChatTheme.of(context).theme.attachmentButtonMargin ??
+          const EdgeInsetsDirectional.fromSTEB(8, 0, 0, 0),
+      child: IconButton(
+        constraints: const BoxConstraints(minHeight: 24, minWidth: 24),
+        icon: isLoading
+            ? SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(
+                  backgroundColor: Colors.transparent,
+                  strokeWidth: 1.5,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    InheritedChatTheme.of(context).theme.inputTextColor,
+                  ),
                 ),
-              ),
-            )
-          : InheritedChatTheme.of(context).theme.attachmentButtonIcon ??
-              Image.asset(
-                'assets/icon-attachment.png',
-                color: InheritedChatTheme.of(context).theme.inputTextColor,
-                package: 'flutter_chat_ui',
-              ),
-      onPressed: isLoading ? null : onPressed,
-      padding: padding,
-      splashRadius: 24,
-      tooltip:
-          InheritedL10n.of(context).l10n.attachmentButtonAccessibilityLabel,
+              )
+            : InheritedChatTheme.of(context).theme.attachmentButtonIcon ??
+                Image.asset(
+                  'assets/icon-attachment.png',
+                  color: InheritedChatTheme.of(context).theme.inputTextColor,
+                  package: 'flutter_chat_ui',
+                ),
+        onPressed: isLoading ? null : onPressed,
+        padding: padding,
+        splashRadius: 24,
+        tooltip:
+            InheritedL10n.of(context).l10n.attachmentButtonAccessibilityLabel,
+      ),
     );
   }
 }

--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -157,14 +157,12 @@ class _InputState extends State<Input> {
             padding: _safeAreaInsets,
             child: Row(
               children: [
-                if (widget.onAttachmentPressed != null) ...[
-                  const SizedBox(width: 8),
+                if (widget.onAttachmentPressed != null)
                   AttachmentButton(
                     isLoading: widget.isAttachmentUploading ?? false,
                     onPressed: widget.onAttachmentPressed,
                     padding: _buttonPadding,
                   ),
-                ],
                 Expanded(
                   child: Padding(
                     padding: _textPadding,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add option to theme that sets the margin for the attachment button analogously to how it is done for the send button.

### Why is it needed?

More styling control

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
