### PR TITLE
Extract reusable widgets for name and avatar and add `avatarBuilder` and `nameBuilder`

### DIFF
--- a/lib/flutter_chat_ui.dart
+++ b/lib/flutter_chat_ui.dart
@@ -9,6 +9,8 @@ export 'src/util.dart' show formatBytes, isConsistsOfEmojis;
 export 'src/widgets/attachment_button.dart';
 export 'src/widgets/chat.dart';
 export 'src/widgets/chat_list.dart';
+export 'src/widgets/chat_user_avatar.dart';
+export 'src/widgets/chat_user_name_header.dart';
 export 'src/widgets/file_message.dart';
 export 'src/widgets/image_message.dart';
 export 'src/widgets/input.dart';

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -178,10 +178,7 @@ List<Object> calculateChatMessages(
     chatMessages.insert(0, {
       'message': message,
       'nextMessageInGroup': nextMessageInGroup,
-      'showName': notMyMessage &&
-          showUserNames &&
-          showName &&
-          getUserName(message.author).isNotEmpty,
+      'showName': notMyMessage && showUserNames && showName,
       'showStatus': message.showStatus ?? true,
     });
 

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -71,6 +71,7 @@ class Chat extends StatefulWidget {
     this.textMessageBuilder,
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
+    this.userBuilder,
     this.usePreviewData = true,
     required this.user,
   }) : super(key: key);
@@ -222,6 +223,10 @@ class Chat extends StatefulWidget {
 
   /// See [Message.showUserAvatars]
   final bool showUserAvatars;
+
+  /// This is to allow custom user builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? userBuilder;
 
   /// Show user names for received messages. Useful for a group chat. Will be
   /// shown only on text messages.
@@ -417,6 +422,7 @@ class _ChatState extends State<Chat> {
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
         usePreviewData: widget.usePreviewData,
+        userBuilder: widget.userBuilder,
       );
     }
   }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -28,6 +28,7 @@ class Chat extends StatefulWidget {
   /// Creates a chat widget
   const Chat({
     Key? key,
+    this.avatarBuilder,
     this.bubbleBuilder,
     this.customBottomWidget,
     this.customDateHeaderText,
@@ -48,6 +49,7 @@ class Chat extends StatefulWidget {
     this.isTextMessageTextSelectable = true,
     this.l10n = const ChatL10nEn(),
     required this.messages,
+    this.nameBuilder,
     this.onAttachmentPressed,
     this.onAvatarTap,
     this.onBackgroundTap,
@@ -71,10 +73,12 @@ class Chat extends StatefulWidget {
     this.textMessageBuilder,
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
-    this.avatarBuilder,
     this.usePreviewData = true,
     required this.user,
   }) : super(key: key);
+
+  /// See [Message.avatarBuilder]
+  final Widget Function(String userId)? avatarBuilder;
 
   /// See [Message.bubbleBuilder]
   final Widget Function(
@@ -165,6 +169,9 @@ class Chat extends StatefulWidget {
   /// List of [types.Message] to render in the chat widget
   final List<types.Message> messages;
 
+  /// See [Message.nameBuilder]
+  final Widget Function(String userId)? nameBuilder;
+
   /// See [Input.onAttachmentPressed]
   final void Function()? onAttachmentPressed;
 
@@ -223,10 +230,6 @@ class Chat extends StatefulWidget {
 
   /// See [Message.showUserAvatars]
   final bool showUserAvatars;
-
-  /// This is to allow custom user builder
-  /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? avatarBuilder;
 
   /// Show user names for received messages. Useful for a group chat. Will be
   /// shown only on text messages.
@@ -390,6 +393,7 @@ class _ChatState extends State<Chat> {
 
       return Message(
         key: ValueKey(message.id),
+        avatarBuilder: widget.avatarBuilder,
         bubbleBuilder: widget.bubbleBuilder,
         customMessageBuilder: widget.customMessageBuilder,
         emojiEnlargementBehavior: widget.emojiEnlargementBehavior,
@@ -399,6 +403,7 @@ class _ChatState extends State<Chat> {
         isTextMessageTextSelectable: widget.isTextMessageTextSelectable,
         message: message,
         messageWidth: _messageWidth,
+        nameBuilder: widget.nameBuilder,
         onAvatarTap: widget.onAvatarTap,
         onMessageDoubleTap: widget.onMessageDoubleTap,
         onMessageLongPress: widget.onMessageLongPress,
@@ -422,7 +427,6 @@ class _ChatState extends State<Chat> {
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
         usePreviewData: widget.usePreviewData,
-        avatarBuilder: widget.avatarBuilder,
       );
     }
   }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -71,7 +71,7 @@ class Chat extends StatefulWidget {
     this.textMessageBuilder,
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
-    this.userBuilder,
+    this.avatarBuilder,
     this.usePreviewData = true,
     required this.user,
   }) : super(key: key);
@@ -226,7 +226,7 @@ class Chat extends StatefulWidget {
 
   /// This is to allow custom user builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? userBuilder;
+  final Widget Function(String userId)? avatarBuilder;
 
   /// Show user names for received messages. Useful for a group chat. Will be
   /// shown only on text messages.
@@ -422,7 +422,7 @@ class _ChatState extends State<Chat> {
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
         usePreviewData: widget.usePreviewData,
-        userBuilder: widget.userBuilder,
+        avatarBuilder: widget.avatarBuilder,
       );
     }
   }

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -78,7 +78,7 @@ class Chat extends StatefulWidget {
   }) : super(key: key);
 
   /// See [Message.avatarBuilder]
-  final Widget Function(String userId)? avatarBuilder;
+  final Widget? Function(String userId)? avatarBuilder;
 
   /// See [Message.bubbleBuilder]
   final Widget Function(
@@ -170,7 +170,7 @@ class Chat extends StatefulWidget {
   final List<types.Message> messages;
 
   /// See [Message.nameBuilder]
-  final Widget Function(String userId)? nameBuilder;
+  final Widget? Function(String userId)? nameBuilder;
 
   /// See [Input.onAttachmentPressed]
   final void Function()? onAttachmentPressed;

--- a/lib/src/widgets/chat_user_avatar.dart
+++ b/lib/src/widgets/chat_user_avatar.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
+import '../util.dart';
+import 'inherited_chat_theme.dart';
+
+/// Render the user's image or initials next to a message
+class ChatUserAvatar extends StatelessWidget {
+  const ChatUserAvatar({
+    Key? key,
+    required this.author,
+    this.onAvatarTap,
+  }) : super(key: key);
+
+  /// Author to show image and name initials from
+  final types.User author;
+
+  /// Called when uses taps on an avatar
+  final void Function(types.User)? onAvatarTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = getUserAvatarNameColor(
+      author,
+      InheritedChatTheme.of(context).theme.userAvatarNameColors,
+    );
+    final hasImage = author.imageUrl != null;
+    final initials = getUserInitials(author);
+
+    return Container(
+      margin: const EdgeInsetsDirectional.only(end: 8),
+      child: GestureDetector(
+        onTap: () => onAvatarTap?.call(author),
+        child: CircleAvatar(
+          backgroundColor: hasImage
+              ? InheritedChatTheme.of(context)
+                  .theme
+                  .userAvatarImageBackgroundColor
+              : color,
+          backgroundImage: hasImage ? NetworkImage(author.imageUrl!) : null,
+          radius: 16,
+          child: !hasImage
+              ? Text(
+                  initials,
+                  style:
+                      InheritedChatTheme.of(context).theme.userAvatarTextStyle,
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/chat_user_name_header.dart
+++ b/lib/src/widgets/chat_user_name_header.dart
@@ -18,14 +18,18 @@ class ChatUserNameHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = InheritedChatTheme.of(context).theme;
     final color = getUserAvatarNameColor(author, theme.userAvatarNameColors);
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 6),
-      child: Text(
-        getUserName(author),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.userNameTextStyle.copyWith(color: color),
-      ),
-    );
+    final name = getUserName(author);
+
+    return name.isEmpty
+        ? const SizedBox()
+        : Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Text(
+              name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.userNameTextStyle.copyWith(color: color),
+            ),
+          );
   }
 }

--- a/lib/src/widgets/chat_user_name_header.dart
+++ b/lib/src/widgets/chat_user_name_header.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
+import '../util.dart';
+import 'inherited_chat_theme.dart';
+
+/// Render the user's name as a message heading according to theme
+class ChatUserNameHeader extends StatelessWidget {
+  const ChatUserNameHeader({
+    Key? key,
+    required this.author,
+  }) : super(key: key);
+
+  /// Author to show name from
+  final types.User author;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = InheritedChatTheme.of(context).theme;
+    final color = getUserAvatarNameColor(author, theme.userAvatarNameColors);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Text(
+        getUserName(author),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.userNameTextStyle.copyWith(color: color),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_ui/src/widgets/chat_user_avatar.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../models/emoji_enlargement_behavior.dart';
@@ -18,6 +19,7 @@ class Message extends StatelessWidget {
   /// Creates a particular message from any message type
   const Message({
     Key? key,
+    this.avatarBuilder,
     this.bubbleBuilder,
     this.customMessageBuilder,
     required this.emojiEnlargementBehavior,
@@ -27,6 +29,7 @@ class Message extends StatelessWidget {
     required this.isTextMessageTextSelectable,
     required this.message,
     required this.messageWidth,
+    this.nameBuilder,
     this.onAvatarTap,
     this.onMessageDoubleTap,
     this.onMessageLongPress,
@@ -42,9 +45,12 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
-    this.avatarBuilder,
     required this.usePreviewData,
   }) : super(key: key);
+
+  /// This is to allow custom user avatar builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? avatarBuilder;
 
   /// Customize the default bubble using this function. `child` is a content
   /// you should render inside your bubble, `message` is a current message
@@ -86,7 +92,10 @@ class Message extends StatelessWidget {
   /// Maximum message width
   final int messageWidth;
 
-  // Called when uses taps on an avatar
+  /// See [TextMessage.nameBuilder]
+  final Widget Function(String userId)? nameBuilder;
+
+  /// See [ChatUserAvatar.onAvatarTap]
   final void Function(types.User)? onAvatarTap;
 
   /// Called when user double taps on any message
@@ -130,10 +139,6 @@ class Message extends StatelessWidget {
   /// Show user avatars for received messages. Useful for a group chat.
   final bool showUserAvatars;
 
-  /// This is to allow custom user builder
-  /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? avatarBuilder;
-
   /// Build a text message inside predefined bubble.
   final Widget Function(
     types.TextMessage, {
@@ -144,44 +149,10 @@ class Message extends StatelessWidget {
   /// See [TextMessage.usePreviewData]
   final bool usePreviewData;
 
-  Widget _avatarBuilder(BuildContext context) {
-    final color = getUserAvatarNameColor(
-      message.author,
-      InheritedChatTheme.of(context).theme.userAvatarNameColors,
-    );
-    final hasImage = message.author.imageUrl != null;
-    final initials = getUserInitials(message.author);
-
-    return showAvatar
-        ? avatarBuilder != null
-            ? avatarBuilder!(message.author.id)
-            : Container(
-                margin: const EdgeInsetsDirectional.only(end: 8),
-                child: GestureDetector(
-                  onTap: () => onAvatarTap?.call(message.author),
-                  child: CircleAvatar(
-                    backgroundColor: hasImage
-                        ? InheritedChatTheme.of(context)
-                            .theme
-                            .userAvatarImageBackgroundColor
-                        : color,
-                    backgroundImage: hasImage
-                        ? NetworkImage(message.author.imageUrl!)
-                        : null,
-                    radius: 16,
-                    child: !hasImage
-                        ? Text(
-                            initials,
-                            style: InheritedChatTheme.of(context)
-                                .theme
-                                .userAvatarTextStyle,
-                          )
-                        : null,
-                  ),
-                ),
-              )
-        : const SizedBox(width: 40);
-  }
+  Widget _avatarBuilder() => showAvatar
+      ? avatarBuilder?.call(message.author.id) ??
+          ChatUserAvatar(author: message.author, onAvatarTap: onAvatarTap)
+      : const SizedBox(width: 40);
 
   Widget _bubbleBuilder(
     BuildContext context,
@@ -242,6 +213,7 @@ class Message extends StatelessWidget {
                 hideBackgroundOnEmojiMessages: hideBackgroundOnEmojiMessages,
                 isTextMessageTextSelectable: isTextMessageTextSelectable,
                 message: textMessage,
+                nameBuilder: nameBuilder,
                 onPreviewDataFetched: onPreviewDataFetched,
                 previewTapOptions: previewTapOptions,
                 showName: showName,
@@ -338,7 +310,7 @@ class Message extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.end,
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (!_currentUserIsAuthor && showUserAvatars) _avatarBuilder(context),
+          if (!_currentUserIsAuthor && showUserAvatars) _avatarBuilder(),
           ConstrainedBox(
             constraints: BoxConstraints(
               maxWidth: messageWidth.toDouble(),

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -42,6 +42,7 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
+    this.userBuilder,
     required this.usePreviewData,
   }) : super(key: key);
 
@@ -129,6 +130,10 @@ class Message extends StatelessWidget {
   /// Show user avatars for received messages. Useful for a group chat.
   final bool showUserAvatars;
 
+  /// This is to allow custom user builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? userBuilder;
+
   /// Build a text message inside predefined bubble.
   final Widget Function(
     types.TextMessage, {
@@ -148,30 +153,33 @@ class Message extends StatelessWidget {
     final initials = getUserInitials(message.author);
 
     return showAvatar
-        ? Container(
-            margin: const EdgeInsetsDirectional.only(end: 8),
-            child: GestureDetector(
-              onTap: () => onAvatarTap?.call(message.author),
-              child: CircleAvatar(
-                backgroundColor: hasImage
-                    ? InheritedChatTheme.of(context)
-                        .theme
-                        .userAvatarImageBackgroundColor
-                    : color,
-                backgroundImage:
-                    hasImage ? NetworkImage(message.author.imageUrl!) : null,
-                radius: 16,
-                child: !hasImage
-                    ? Text(
-                        initials,
-                        style: InheritedChatTheme.of(context)
+        ? userBuilder != null
+            ? userBuilder!(message.author.id)
+            : Container(
+                margin: const EdgeInsetsDirectional.only(end: 8),
+                child: GestureDetector(
+                  onTap: () => onAvatarTap?.call(message.author),
+                  child: CircleAvatar(
+                    backgroundColor: hasImage
+                        ? InheritedChatTheme.of(context)
                             .theme
-                            .userAvatarTextStyle,
-                      )
-                    : null,
-              ),
-            ),
-          )
+                            .userAvatarImageBackgroundColor
+                        : color,
+                    backgroundImage: hasImage
+                        ? NetworkImage(message.author.imageUrl!)
+                        : null,
+                    radius: 16,
+                    child: !hasImage
+                        ? Text(
+                            initials,
+                            style: InheritedChatTheme.of(context)
+                                .theme
+                                .userAvatarTextStyle,
+                          )
+                        : null,
+                  ),
+                ),
+              )
         : const SizedBox(width: 40);
   }
 

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -42,7 +42,7 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
-    this.userBuilder,
+    this.avatarBuilder,
     required this.usePreviewData,
   }) : super(key: key);
 
@@ -132,7 +132,7 @@ class Message extends StatelessWidget {
 
   /// This is to allow custom user builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? userBuilder;
+  final Widget Function(String userId)? avatarBuilder;
 
   /// Build a text message inside predefined bubble.
   final Widget Function(
@@ -153,8 +153,8 @@ class Message extends StatelessWidget {
     final initials = getUserInitials(message.author);
 
     return showAvatar
-        ? userBuilder != null
-            ? userBuilder!(message.author.id)
+        ? avatarBuilder != null
+            ? avatarBuilder!(message.author.id)
             : Container(
                 margin: const EdgeInsetsDirectional.only(end: 8),
                 child: GestureDetector(

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -50,7 +50,7 @@ class Message extends StatelessWidget {
 
   /// This is to allow custom user avatar builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? avatarBuilder;
+  final Widget? Function(String userId)? avatarBuilder;
 
   /// Customize the default bubble using this function. `child` is a content
   /// you should render inside your bubble, `message` is a current message
@@ -93,7 +93,7 @@ class Message extends StatelessWidget {
   final int messageWidth;
 
   /// See [TextMessage.nameBuilder]
-  final Widget Function(String userId)? nameBuilder;
+  final Widget? Function(String userId)? nameBuilder;
 
   /// See [ChatUserAvatar.onAvatarTap]
   final void Function(types.User)? onAvatarTap;

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_ui/src/widgets/chat_user_name_header.dart';
 import 'package:flutter_link_previewer/flutter_link_previewer.dart'
     show LinkPreview, regexEmail, regexLink;
 import 'package:flutter_parsed_text/flutter_parsed_text.dart';
@@ -20,6 +21,7 @@ class TextMessage extends StatelessWidget {
     required this.hideBackgroundOnEmojiMessages,
     required this.isTextMessageTextSelectable,
     required this.message,
+    this.nameBuilder,
     this.onPreviewDataFetched,
     required this.previewTapOptions,
     required this.usePreviewData,
@@ -37,6 +39,10 @@ class TextMessage extends StatelessWidget {
 
   /// [types.TextMessage]
   final types.TextMessage message;
+
+  /// This is to allow custom user name builder
+  /// By using this we can fetch newest user info based on id
+  final Widget Function(String userId)? nameBuilder;
 
   /// See [LinkPreview.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?
@@ -101,9 +107,6 @@ class TextMessage extends StatelessWidget {
   ) {
     final isIOS = Theme.of(context).platform == TargetPlatform.iOS;
     final theme = InheritedChatTheme.of(context).theme;
-    final color =
-        getUserAvatarNameColor(message.author, theme.userAvatarNameColors);
-    final name = getUserName(message.author);
     final bodyLinkTextStyle = user.id == message.author.id
         ? InheritedChatTheme.of(context).theme.sentMessageBodyLinkTextStyle
         : InheritedChatTheme.of(context).theme.receivedMessageBodyLinkTextStyle;
@@ -125,15 +128,8 @@ class TextMessage extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (showName)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 6),
-            child: Text(
-              name,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.userNameTextStyle.copyWith(color: color),
-            ),
-          ),
+          nameBuilder?.call(message.author.id) ??
+              ChatUserNameHeader(author: message.author),
         ParsedText(
           parse: [
             MatchText(

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -42,7 +42,7 @@ class TextMessage extends StatelessWidget {
 
   /// This is to allow custom user name builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? nameBuilder;
+  final Widget? Function(String userId)? nameBuilder;
 
   /// See [LinkPreview.onPreviewDataFetched]
   final void Function(types.TextMessage, types.PreviewData)?


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

As described in #231, it is now possible to both override the name and avatar builder but also to reuse the current design with updated author data.

### Why is it needed?

For one, we do not want to have to update the author fields for all messages when the profile picture changes.

Also, it should be possible to specify how the avatar is rendered. This allows us to add things like a loading spinner and such, or reuse already existing image caching logic.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Builds on top of #231, much of the credit goes to @dariuspo. Will make #207 irrelevant.