### PR TITLE
Allow opening loose urls

### DIFF
--- a/example/assets/messages.json
+++ b/example/assets/messages.json
@@ -8,7 +8,7 @@
     "createdAt": 1598438796000,
     "id": "9dcc55c2-2a28-492e-817b-aa81feec86d7",
     "status": "seen",
-    "text": "**bold** _italic_ ~strikethrough~ `code`\nhttps://flyer.chat alexdemchenko@yahoo.com",
+    "text": "**bold** _italic_ ~strikethrough~ `code`\nhttps://flyer.chat flyer.chat alexdemchenko@yahoo.com",
     "type": "text"
   },
   {

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -139,9 +139,9 @@ class TextMessage extends StatelessWidget {
             parse: [
               MatchText(
                 onTap: (mail) async {
-                  final url = 'mailto:$mail';
-                  if (await canLaunch(url)) {
-                    await launch(url);
+                  final url = Uri(scheme: 'mailto', path: mail);
+                  if (await canLaunchUrl(url)) {
+                    await launchUrl(url);
                   }
                 },
                 pattern: regexEmail,
@@ -151,9 +151,17 @@ class TextMessage extends StatelessWidget {
                     ),
               ),
               MatchText(
-                onTap: (url) async {
-                  if (await canLaunch(url)) {
-                    await launch(url);
+                onTap: (urlText) async {
+                  final protocolIdentifierRegex = RegExp(
+                    r'^((http|ftp|https):\/\/)',
+                    caseSensitive: false,
+                  );
+                  if (!urlText.startsWith(protocolIdentifierRegex)) {
+                    urlText = "https://" + urlText;
+                  }
+                  final url = Uri.tryParse(urlText);
+                  if (url != null && await canLaunchUrl(url)) {
+                    await launchUrl(url);
                   }
                 },
                 pattern: regexLink,

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -161,7 +161,7 @@ class TextMessage extends StatelessWidget {
                   }
                   final url = Uri.tryParse(urlText);
                   if (url != null && await canLaunchUrl(url)) {
-                    await launchUrl(url);
+                    await launchUrl(url, mode: LaunchMode.externalApplication);
                   }
                 },
                 pattern: regexLink,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Default to `https://` if no scheme in URL when trying to open it.

### Why is it needed?

One regression with the switch from `linkify` to `flutter_parsed_text` was that loose URLs were still recognized but could not be opened just like that by `url_launcher`.

### How to test it?

Run the example app and click on the `flyer.chat` link.

### Related issues/PRs

https://github.com/flyerhq/flutter_chat_ui/pull/260 also performed the migration to `canLaunchUrl`/`launchUrl`.
