### PR TITLE
Add parameter to pass headers when grabbing User's imageUrl

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -41,6 +41,7 @@ class Chat extends StatefulWidget {
     this.emojiEnlargementBehavior = EmojiEnlargementBehavior.multi,
     this.emptyState,
     this.fileMessageBuilder,
+    this.headers,
     this.groupMessagesThreshold = 60000,
     this.hideBackgroundOnEmojiMessages = true,
     this.imageMessageBuilder,
@@ -136,6 +137,9 @@ class Chat extends StatefulWidget {
   /// `emptyChatPlaceholder` and `emptyChatPlaceholderTextStyle` are ignored
   /// in this case.
   final Widget? emptyState;
+
+  /// See [Message.headers]
+  final Map<String, String>? headers;
 
   /// See [Message.fileMessageBuilder]
   final Widget Function(types.FileMessage, {required int messageWidth})?
@@ -402,6 +406,7 @@ class _ChatState extends State<Chat> {
         customMessageBuilder: widget.customMessageBuilder,
         emojiEnlargementBehavior: widget.emojiEnlargementBehavior,
         fileMessageBuilder: widget.fileMessageBuilder,
+        headers: widget.headers,
         hideBackgroundOnEmojiMessages: widget.hideBackgroundOnEmojiMessages,
         imageMessageBuilder: widget.imageMessageBuilder,
         isTextMessageTextSelectable: widget.isTextMessageTextSelectable,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -25,6 +25,7 @@ class Message extends StatelessWidget {
     this.customMessageBuilder,
     required this.emojiEnlargementBehavior,
     this.fileMessageBuilder,
+    this.headers,
     required this.hideBackgroundOnEmojiMessages,
     this.imageMessageBuilder,
     required this.isTextMessageTextSelectable,
@@ -76,6 +77,9 @@ class Message extends StatelessWidget {
   /// Build a file message inside predefined bubble
   final Widget Function(types.FileMessage, {required int messageWidth})?
       fileMessageBuilder;
+
+  /// See [UserAvatar.headers]
+  final Map<String, String>? headers;
 
   /// Hide background for messages containing only emojis.
   final bool hideBackgroundOnEmojiMessages;
@@ -152,7 +156,7 @@ class Message extends StatelessWidget {
 
   Widget _avatarBuilder() => showAvatar
       ? avatarBuilder?.call(message.author.id) ??
-          UserAvatar(author: message.author, onAvatarTap: onAvatarTap)
+          UserAvatar(author: message.author, headers: headers, onAvatarTap: onAvatarTap)
       : const SizedBox(width: 40);
 
   Widget _bubbleBuilder(

--- a/lib/src/widgets/user_avatar.dart
+++ b/lib/src/widgets/user_avatar.dart
@@ -10,6 +10,7 @@ class UserAvatar extends StatelessWidget {
   const UserAvatar({
     Key? key,
     required this.author,
+    this.headers,
     this.onAvatarTap,
   }) : super(key: key);
 
@@ -18,6 +19,9 @@ class UserAvatar extends StatelessWidget {
 
   /// Called when user taps on an avatar
   final void Function(types.User)? onAvatarTap;
+
+  /// Headers to use when fetching image
+  final Map<String, String>? headers;
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +42,7 @@ class UserAvatar extends StatelessWidget {
                   .theme
                   .userAvatarImageBackgroundColor
               : color,
-          backgroundImage: hasImage ? NetworkImage(author.imageUrl!) : null,
+          backgroundImage: hasImage ? NetworkImage(author.imageUrl!, headers: headers) : null,
           radius: 16,
           child: !hasImage
               ? Text(


### PR DESCRIPTION
### What does it do?

You are now able to pass in auth headers when grabbing an image.

### Why is it needed?

The images that are being grabbed require a token to be passed in the header.
