### PR TITLE
:sparkles: Add CustomMessageBuilder

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -33,6 +33,7 @@ class Chat extends StatefulWidget {
     this.customBottomWidget,
     this.customDateHeaderText,
     this.customMessageBuilder,
+    this.customStatusBuilder,
     this.dateFormat,
     this.dateHeaderBuilder,
     this.dateHeaderThreshold = 900000,
@@ -105,6 +106,10 @@ class Chat extends StatefulWidget {
   /// See [Message.customMessageBuilder].
   final Widget Function(types.CustomMessage, {required int messageWidth})?
       customMessageBuilder;
+
+  /// See [Message.customStatusBuilder]
+  final Widget Function(types.Message message, {required BuildContext context})?
+      customStatusBuilder;
 
   /// Allows you to customize the date format. IMPORTANT: only for the date,
   /// do not return time here. See [timeFormat] to customize the time format.

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -107,7 +107,7 @@ class Chat extends StatefulWidget {
   final Widget Function(types.CustomMessage, {required int messageWidth})?
       customMessageBuilder;
 
-  /// See [Message.customStatusBuilder]
+  /// See [Message.customStatusBuilder].
   final Widget Function(types.Message message, {required BuildContext context})?
       customStatusBuilder;
 

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -463,6 +463,7 @@ class _ChatState extends State<Chat> {
         avatarBuilder: widget.avatarBuilder,
         bubbleBuilder: widget.bubbleBuilder,
         customMessageBuilder: widget.customMessageBuilder,
+        customStatusBuilder: widget.customStatusBuilder,
         emojiEnlargementBehavior: widget.emojiEnlargementBehavior,
         fileMessageBuilder: widget.fileMessageBuilder,
         hideBackgroundOnEmojiMessages: widget.hideBackgroundOnEmojiMessages,

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -23,6 +23,7 @@ class Message extends StatelessWidget {
     this.avatarBuilder,
     this.bubbleBuilder,
     this.customMessageBuilder,
+    this.customStatusBuilder,
     required this.emojiEnlargementBehavior,
     this.fileMessageBuilder,
     required this.hideBackgroundOnEmojiMessages,
@@ -68,6 +69,10 @@ class Message extends StatelessWidget {
   /// Build a custom message inside predefined bubble.
   final Widget Function(types.CustomMessage, {required int messageWidth})?
       customMessageBuilder;
+
+  /// Build a custom status widgets.
+  final Widget Function(types.Message message, {required BuildContext context})?
+      customStatusBuilder;
 
   /// Controls the enlargement behavior of the emojis in the
   /// [types.TextMessage].
@@ -241,7 +246,9 @@ class Message extends StatelessWidget {
                       onLongPress: () =>
                           onMessageStatusLongPress?.call(context, message),
                       onTap: () => onMessageStatusTap?.call(context, message),
-                      child: _statusBuilder(context),
+                      child: customStatusBuilder != null
+                          ? customStatusBuilder!(message, context: context)
+                          : _statusBuilder(context),
                     )
                   : null,
             ),


### PR DESCRIPTION
### What does it do?

We can build custom status widgets with message property.

### Why is it needed?

We may want to display the number of people who have read your messages, and their avatars like other chat apps. I would be happy if I could freely pass the Widget with a message to the status Widget at that time!
Currently, it is not possible to change the status Icon based on the message data.

### How to test it?

set `customStatusBuilder` to Chat Widget.

### Related issues/PRs

We talked about it here.
https://github.com/flyerhq/flutter_chat_ui/discussions/281