### PR TITLE
Add text message options to customize opening links

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -22,6 +22,7 @@ import 'inherited_l10n.dart';
 import 'inherited_user.dart';
 import 'input.dart';
 import 'message.dart';
+import 'text_message.dart';
 
 /// Entry widget, represents the complete chat. If you wrap it in [SafeArea] and
 /// it should be full screen, set [SafeArea]'s `bottom` to `false`.
@@ -75,6 +76,7 @@ class Chat extends StatefulWidget {
     this.showUserAvatars = false,
     this.showUserNames = false,
     this.textMessageBuilder,
+    this.textMessageOptions = const TextMessageOptions(),
     this.theme = const DefaultChatTheme(),
     this.timeFormat,
     this.usePreviewData = true,
@@ -256,6 +258,9 @@ class Chat extends StatefulWidget {
     required int messageWidth,
     required bool showName,
   })? textMessageBuilder;
+
+  /// See [Message.textMessageOptions].
+  final TextMessageOptions textMessageOptions;
 
   /// Chat theme. Extend [ChatTheme] class to create your own theme or use
   /// existing one, like the [DefaultChatTheme]. You can customize only certain
@@ -500,6 +505,7 @@ class _ChatState extends State<Chat> {
         showStatus: map['showStatus'] == true,
         showUserAvatars: widget.showUserAvatars,
         textMessageBuilder: widget.textMessageBuilder,
+        textMessageOptions: widget.textMessageOptions,
         usePreviewData: widget.usePreviewData,
         userAgent: widget.userAgent,
       );

--- a/lib/src/widgets/message.dart
+++ b/lib/src/widgets/message.dart
@@ -49,6 +49,7 @@ class Message extends StatelessWidget {
     required this.showStatus,
     required this.showUserAvatars,
     this.textMessageBuilder,
+    required this.textMessageOptions,
     required this.usePreviewData,
     this.userAgent,
   });
@@ -158,6 +159,9 @@ class Message extends StatelessWidget {
     required int messageWidth,
     required bool showName,
   })? textMessageBuilder;
+
+  /// See [TextMessage.options].
+  final TextMessageOptions textMessageOptions;
 
   /// See [TextMessage.usePreviewData].
   final bool usePreviewData;
@@ -360,6 +364,7 @@ class Message extends StatelessWidget {
                 message: textMessage,
                 nameBuilder: nameBuilder,
                 onPreviewDataFetched: onPreviewDataFetched,
+                options: textMessageOptions,
                 previewTapOptions: previewTapOptions,
                 showName: showName,
                 usePreviewData: usePreviewData,

--- a/lib/src/widgets/text_message.dart
+++ b/lib/src/widgets/text_message.dart
@@ -24,6 +24,7 @@ class TextMessage extends StatelessWidget {
     required this.message,
     this.nameBuilder,
     this.onPreviewDataFetched,
+    this.options = const TextMessageOptions(),
     required this.previewTapOptions,
     required this.showName,
     required this.usePreviewData,
@@ -49,6 +50,8 @@ class TextMessage extends StatelessWidget {
   /// See [LinkPreview.onPreviewDataFetched].
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
+
+  final TextMessageOptions options;
 
   /// See [LinkPreview.openOnPreviewImageTap] and [LinkPreview.openOnPreviewTitleTap].
   final PreviewTapOptions previewTapOptions;
@@ -111,6 +114,7 @@ class TextMessage extends StatelessWidget {
       enableAnimation: true,
       metadataTextStyle: linkDescriptionTextStyle,
       metadataTitleStyle: linkTitleTextStyle,
+      onLinkPressed: options.onLinkPressed,
       onPreviewDataFetched: _onPreviewDataFetched,
       openOnPreviewImageTap: previewTapOptions.openOnImageTap,
       openOnPreviewTitleTap: previewTapOptions.openOnTitleTap,
@@ -191,9 +195,16 @@ class TextMessage extends StatelessWidget {
                   if (!urlText.startsWith(protocolIdentifierRegex)) {
                     urlText = 'https://$urlText';
                   }
-                  final url = Uri.tryParse(urlText);
-                  if (url != null && await canLaunchUrl(url)) {
-                    await launchUrl(url, mode: LaunchMode.externalApplication);
+                  if (options.onLinkPressed != null) {
+                    options.onLinkPressed!(urlText);
+                  } else {
+                    final url = Uri.tryParse(urlText);
+                    if (url != null && await canLaunchUrl(url)) {
+                      await launchUrl(
+                        url,
+                        mode: LaunchMode.externalApplication,
+                      );
+                    }
                   }
                 },
                 pattern: regexLink,
@@ -258,4 +269,14 @@ class TextMessage extends StatelessWidget {
       ],
     );
   }
+}
+
+@immutable
+class TextMessageOptions {
+  const TextMessageOptions({
+    this.onLinkPressed,
+  });
+
+  /// Custom link press handler.
+  final void Function(String)? onLinkPressed;
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Users can now specify how exactly links should open (e.g. use different launch mode or handle certain links inside their app). I also implemented a first draft options object for text messages which we could work off of.

### Why is it needed?

Some apps have deep links that could be opened immediately without opening another browser.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
