### PR TITLE
Improve image gallery

### DIFF
--- a/lib/flutter_chat_ui.dart
+++ b/lib/flutter_chat_ui.dart
@@ -11,6 +11,7 @@ export 'src/widgets/attachment_button.dart';
 export 'src/widgets/chat.dart';
 export 'src/widgets/chat_list.dart';
 export 'src/widgets/file_message.dart';
+export 'src/widgets/image_gallery.dart';
 export 'src/widgets/image_message.dart';
 export 'src/widgets/input.dart';
 export 'src/widgets/input_text_field_controller.dart';

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -3,11 +3,9 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:intl/intl.dart';
-import 'package:photo_view/photo_view_gallery.dart';
 
 import '../chat_l10n.dart';
 import '../chat_theme.dart';
-import '../conditional/conditional.dart';
 import '../models/bubble_rtl_alignment.dart';
 import '../models/date_header.dart';
 import '../models/emoji_enlargement_behavior.dart';
@@ -17,6 +15,7 @@ import '../models/preview_tap_options.dart';
 import '../models/send_button_visibility_mode.dart';
 import '../util.dart';
 import 'chat_list.dart';
+import 'image_gallery.dart';
 import 'inherited_chat_theme.dart';
 import 'inherited_l10n.dart';
 import 'inherited_user.dart';
@@ -299,7 +298,7 @@ class Chat extends StatefulWidget {
 class _ChatState extends State<Chat> {
   List<Object> _chatMessages = [];
   List<PreviewImage> _gallery = [];
-  int _imageViewIndex = 0;
+  PageController? _galleryPageController;
   bool _isImageViewVisible = false;
 
   @override
@@ -329,6 +328,12 @@ class _ChatState extends State<Chat> {
       _chatMessages = result[0] as List<Object>;
       _gallery = result[1] as List<PreviewImage>;
     }
+  }
+
+  @override
+  void dispose() {
+    _galleryPageController?.dispose();
+    super.dispose();
   }
 
   @override
@@ -389,7 +394,12 @@ class _ChatState extends State<Chat> {
                     ],
                   ),
                 ),
-                if (_isImageViewVisible) _imageGalleryBuilder(),
+                if (_isImageViewVisible)
+                  ImageGallery(
+                    images: _gallery,
+                    pageController: _galleryPageController!,
+                    onClosePressed: _onCloseGalleryPressed,
+                  ),
               ],
             ),
           ),
@@ -407,49 +417,6 @@ class _ChatState extends State<Chat> {
           widget.l10n.emptyChatPlaceholder,
           style: widget.theme.emptyChatPlaceholderTextStyle,
           textAlign: TextAlign.center,
-        ),
-      );
-
-  Widget _imageGalleryBuilder() => Dismissible(
-        key: const Key('photo_view_gallery'),
-        direction: DismissDirection.down,
-        onDismissed: (direction) => _onCloseGalleryPressed(),
-        child: Stack(
-          children: [
-            PhotoViewGallery.builder(
-              builder: (BuildContext context, int index) =>
-                  PhotoViewGalleryPageOptions(
-                imageProvider: Conditional().getProvider(_gallery[index].uri),
-              ),
-              itemCount: _gallery.length,
-              loadingBuilder: (context, event) =>
-                  _imageGalleryLoadingBuilder(event),
-              onPageChanged: _onPageChanged,
-              pageController: PageController(initialPage: _imageViewIndex),
-              scrollPhysics: const ClampingScrollPhysics(),
-            ),
-            Positioned.directional(
-              end: 16,
-              textDirection: Directionality.of(context),
-              top: 56,
-              child: CloseButton(
-                color: Colors.white,
-                onPressed: _onCloseGalleryPressed,
-              ),
-            ),
-          ],
-        ),
-      );
-
-  Widget _imageGalleryLoadingBuilder(ImageChunkEvent? event) => Center(
-        child: SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(
-            value: event == null || event.expectedTotalBytes == null
-                ? 0
-                : event.cumulativeBytesLoaded / event.expectedTotalBytes!,
-          ),
         ),
       );
 
@@ -527,20 +494,16 @@ class _ChatState extends State<Chat> {
     setState(() {
       _isImageViewVisible = false;
     });
+    _galleryPageController?.dispose();
   }
 
   void _onImagePressed(types.ImageMessage message) {
+    final initialIndex = _gallery.indexWhere(
+      (element) => element.id == message.id && element.uri == message.uri,
+    );
+    _galleryPageController = PageController(initialPage: initialIndex);
     setState(() {
-      _imageViewIndex = _gallery.indexWhere(
-        (element) => element.id == message.id && element.uri == message.uri,
-      );
       _isImageViewVisible = true;
-    });
-  }
-
-  void _onPageChanged(int index) {
-    setState(() {
-      _imageViewIndex = index;
     });
   }
 

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -503,6 +503,7 @@ class _ChatState extends State<Chat> {
       _isImageViewVisible = false;
     });
     _galleryPageController?.dispose();
+    _galleryPageController = null;
   }
 
   void _onImagePressed(types.ImageMessage message) {

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -46,6 +46,10 @@ class Chat extends StatefulWidget {
     this.fileMessageBuilder,
     this.groupMessagesThreshold = 60000,
     this.hideBackgroundOnEmojiMessages = true,
+    this.imageGalleryOptions = const ImageGalleryOptions(
+      maxScale: PhotoViewComputedScale.covered,
+      minScale: PhotoViewComputedScale.contained,
+    ),
     this.imageMessageBuilder,
     this.isAttachmentUploading,
     this.isLastPage,
@@ -162,6 +166,9 @@ class Chat extends StatefulWidget {
 
   /// See [Message.hideBackgroundOnEmojiMessages].
   final bool hideBackgroundOnEmojiMessages;
+
+  /// See [ImageGallery.options].
+  final ImageGalleryOptions imageGalleryOptions;
 
   /// See [Message.imageMessageBuilder].
   final Widget Function(types.ImageMessage, {required int messageWidth})?
@@ -399,6 +406,7 @@ class _ChatState extends State<Chat> {
                     images: _gallery,
                     pageController: _galleryPageController!,
                     onClosePressed: _onCloseGalleryPressed,
+                    options: widget.imageGalleryOptions,
                   ),
               ],
             ),

--- a/lib/src/widgets/image_gallery.dart
+++ b/lib/src/widgets/image_gallery.dart
@@ -10,16 +10,13 @@ class ImageGallery extends StatelessWidget {
   const ImageGallery({
     super.key,
     required this.images,
-    required this.pageController,
     required this.onClosePressed,
     this.options = const ImageGalleryOptions(),
+    required this.pageController,
   });
 
   /// Images to show in the gallery.
   final List<PreviewImage> images;
-
-  /// Page controller for the image pages.
-  final PageController pageController;
 
   /// Triggered when the gallery is swiped down or closed via the icon.
   final VoidCallback onClosePressed;
@@ -27,13 +24,16 @@ class ImageGallery extends StatelessWidget {
   /// Customisation options for the gallery.
   final ImageGalleryOptions options;
 
+  /// Page controller for the image pages.
+  final PageController pageController;
+
   @override
   Widget build(BuildContext context) => WillPopScope(
-    onWillPop: () async {
-      onClosePressed();
-      return false;
-    },
-    child: Dismissible(
+        onWillPop: () async {
+          onClosePressed();
+          return false;
+        },
+        child: Dismissible(
           key: const Key('photo_view_gallery'),
           direction: DismissDirection.down,
           onDismissed: (direction) => onClosePressed(),
@@ -64,7 +64,7 @@ class ImageGallery extends StatelessWidget {
             ],
           ),
         ),
-  );
+      );
 
   Widget _imageGalleryLoadingBuilder(ImageChunkEvent? event) => Center(
         child: SizedBox(
@@ -81,13 +81,13 @@ class ImageGallery extends StatelessWidget {
 
 class ImageGalleryOptions {
   const ImageGalleryOptions({
-    this.minScale,
     this.maxScale,
+    this.minScale,
   });
-
-  /// See [PhotoViewGalleryPageOptions.minScale].
-  final dynamic minScale;
 
   /// See [PhotoViewGalleryPageOptions.maxScale].
   final dynamic maxScale;
+
+  /// See [PhotoViewGalleryPageOptions.minScale].
+  final dynamic minScale;
 }

--- a/lib/src/widgets/image_gallery.dart
+++ b/lib/src/widgets/image_gallery.dart
@@ -28,38 +28,43 @@ class ImageGallery extends StatelessWidget {
   final ImageGalleryOptions options;
 
   @override
-  Widget build(BuildContext context) => Dismissible(
-        key: const Key('photo_view_gallery'),
-        direction: DismissDirection.down,
-        onDismissed: (direction) => onClosePressed(),
-        child: Stack(
-          children: [
-            PhotoViewGallery.builder(
-              builder: (BuildContext context, int index) =>
-                  PhotoViewGalleryPageOptions(
-                imageProvider: Conditional().getProvider(images[index].uri),
-                minScale: options.minScale,
-                maxScale: options.maxScale,
+  Widget build(BuildContext context) => WillPopScope(
+    onWillPop: () async {
+      onClosePressed();
+      return false;
+    },
+    child: Dismissible(
+          key: const Key('photo_view_gallery'),
+          direction: DismissDirection.down,
+          onDismissed: (direction) => onClosePressed(),
+          child: Stack(
+            children: [
+              PhotoViewGallery.builder(
+                builder: (BuildContext context, int index) =>
+                    PhotoViewGalleryPageOptions(
+                  imageProvider: Conditional().getProvider(images[index].uri),
+                  minScale: options.minScale,
+                  maxScale: options.maxScale,
+                ),
+                itemCount: images.length,
+                loadingBuilder: (context, event) =>
+                    _imageGalleryLoadingBuilder(event),
+                pageController: pageController,
+                scrollPhysics: const ClampingScrollPhysics(),
               ),
-              itemCount: images.length,
-              loadingBuilder: (context, event) =>
-                  _imageGalleryLoadingBuilder(event),
-              onPageChanged: (_) {},
-              pageController: pageController,
-              scrollPhysics: const ClampingScrollPhysics(),
-            ),
-            Positioned.directional(
-              end: 16,
-              textDirection: Directionality.of(context),
-              top: 56,
-              child: CloseButton(
-                color: Colors.white,
-                onPressed: onClosePressed,
+              Positioned.directional(
+                end: 16,
+                textDirection: Directionality.of(context),
+                top: 56,
+                child: CloseButton(
+                  color: Colors.white,
+                  onPressed: onClosePressed,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      );
+  );
 
   Widget _imageGalleryLoadingBuilder(ImageChunkEvent? event) => Center(
         child: SizedBox(

--- a/lib/src/widgets/image_gallery.dart
+++ b/lib/src/widgets/image_gallery.dart
@@ -4,17 +4,28 @@ import 'package:photo_view/photo_view_gallery.dart';
 import '../conditional/conditional.dart';
 import '../models/preview_image.dart';
 
+export 'package:photo_view/photo_view.dart' show PhotoViewComputedScale;
+
 class ImageGallery extends StatelessWidget {
   const ImageGallery({
     super.key,
     required this.images,
     required this.pageController,
     required this.onClosePressed,
+    this.options = const ImageGalleryOptions(),
   });
 
+  /// Images to show in the gallery.
   final List<PreviewImage> images;
+
+  /// Page controller for the image pages.
   final PageController pageController;
+
+  /// Triggered when the gallery is swiped down or closed via the icon.
   final VoidCallback onClosePressed;
+
+  /// Customisation options for the gallery.
+  final ImageGalleryOptions options;
 
   @override
   Widget build(BuildContext context) => Dismissible(
@@ -27,6 +38,8 @@ class ImageGallery extends StatelessWidget {
               builder: (BuildContext context, int index) =>
                   PhotoViewGalleryPageOptions(
                 imageProvider: Conditional().getProvider(images[index].uri),
+                minScale: options.minScale,
+                maxScale: options.maxScale,
               ),
               itemCount: images.length,
               loadingBuilder: (context, event) =>
@@ -49,14 +62,27 @@ class ImageGallery extends StatelessWidget {
       );
 
   Widget _imageGalleryLoadingBuilder(ImageChunkEvent? event) => Center(
-    child: SizedBox(
-      width: 20,
-      height: 20,
-      child: CircularProgressIndicator(
-        value: event == null || event.expectedTotalBytes == null
-            ? 0
-            : event.cumulativeBytesLoaded / event.expectedTotalBytes!,
-      ),
-    ),
-  );
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(
+            value: event == null || event.expectedTotalBytes == null
+                ? 0
+                : event.cumulativeBytesLoaded / event.expectedTotalBytes!,
+          ),
+        ),
+      );
+}
+
+class ImageGalleryOptions {
+  const ImageGalleryOptions({
+    this.minScale,
+    this.maxScale,
+  });
+
+  /// See [PhotoViewGalleryPageOptions.minScale].
+  final dynamic minScale;
+
+  /// See [PhotoViewGalleryPageOptions.maxScale].
+  final dynamic maxScale;
 }

--- a/lib/src/widgets/image_gallery.dart
+++ b/lib/src/widgets/image_gallery.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+
+import '../conditional/conditional.dart';
+import '../models/preview_image.dart';
+
+class ImageGallery extends StatelessWidget {
+  const ImageGallery({
+    super.key,
+    required this.images,
+    required this.pageController,
+    required this.onClosePressed,
+  });
+
+  final List<PreviewImage> images;
+  final PageController pageController;
+  final VoidCallback onClosePressed;
+
+  @override
+  Widget build(BuildContext context) => Dismissible(
+        key: const Key('photo_view_gallery'),
+        direction: DismissDirection.down,
+        onDismissed: (direction) => onClosePressed(),
+        child: Stack(
+          children: [
+            PhotoViewGallery.builder(
+              builder: (BuildContext context, int index) =>
+                  PhotoViewGalleryPageOptions(
+                imageProvider: Conditional().getProvider(images[index].uri),
+              ),
+              itemCount: images.length,
+              loadingBuilder: (context, event) =>
+                  _imageGalleryLoadingBuilder(event),
+              onPageChanged: (_) {},
+              pageController: pageController,
+              scrollPhysics: const ClampingScrollPhysics(),
+            ),
+            Positioned.directional(
+              end: 16,
+              textDirection: Directionality.of(context),
+              top: 56,
+              child: CloseButton(
+                color: Colors.white,
+                onPressed: onClosePressed,
+              ),
+            ),
+          ],
+        ),
+      );
+
+  Widget _imageGalleryLoadingBuilder(ImageChunkEvent? event) => Center(
+    child: SizedBox(
+      width: 20,
+      height: 20,
+      child: CircularProgressIndicator(
+        value: event == null || event.expectedTotalBytes == null
+            ? 0
+            : event.cumulativeBytesLoaded / event.expectedTotalBytes!,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Extracted image gallery widget to clean up code.
- Add scaling parameters and find better default min/max scales than infinity.
- Back button now just closes the gallery and not the whole example app (could be made configurable, what do you think?)

### Why is it needed?

The image gallery always felt a bit weird to use to me. The features mentioned above are what I would expect from a regular chat app image gallery.

### How to test it?

Just run the example app.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
