### PR TITLE
Input text container changes size (when field is empty, compared to not empty)

### DIFF
--- a/lib/src/widgets/input.dart
+++ b/lib/src/widgets/input.dart
@@ -264,6 +264,9 @@ class _InputState extends State<Input> {
                 ),
                 Visibility(
                   visible: _sendButtonVisible,
+                  maintainSize: true,
+                  maintainAnimation: true,
+                  maintainState: true,
                   child: SendButton(
                     onPressed: _handleSendPressed,
                     padding: buttonPadding,


### PR DESCRIPTION
Fix for the input container changing size when typing something (compared to when the field is empty).

Before:
![before](https://user-images.githubusercontent.com/52532656/179192452-d7597308-56f2-4010-80fc-e3f655b4dd69.gif)

Now: 
![after](https://user-images.githubusercontent.com/52532656/179192485-da682784-8f7b-48ce-9d86-f2b994069875.gif)

