### PR TITLE
Avoid unnecessary rebuilds of message widgets, allow selective State KeepAlive

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -439,7 +439,6 @@ class _ChatState extends State<Chat> {
               : min(constraints.maxWidth * 0.78, 440).floor();
 
       return Message(
-        key: ValueKey(message.id),
         avatarBuilder: widget.avatarBuilder,
         bubbleBuilder: widget.bubbleBuilder,
         bubbleRtlAlignment: widget.bubbleRtlAlignment,

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -274,7 +274,7 @@ class _AnimatedMessageState extends State<AnimatedMessage>
 
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 100),
+      duration: const Duration(milliseconds: 300),
     );
 
     _animation = CurvedAnimation(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
   flutter: ">=2.0.0"
 
 dependencies:
-  diffutil_dart: ^3.0.0
   equatable: ^2.0.3
   flutter:
     sdk: flutter


### PR DESCRIPTION
Fixes #287

Uses `SliverList` with `findChildIndexCallback` to avoid rebuilds of messages and retain State.

Animates new messages using a `AnimatedMessage` wrapper that performs the same animation that was previously provided through `SliverAnimatedList`.

Previously "seen" messages are not animated. We track seen messages in a `Set` of `messageIds`. The initially provided messages are all considered "seen". Any messages added later are considered un-seen.

Custom messages can extend flutter's `AutomaticKeepAliveClientMixin` and `@override bool get wantKeepAlive => true;` to selectively retain their state _**even if they scroll out of view**_. Without this setting, message widgets will still _not_ be rebuilt as long as they are in view, but will be destroyed otherwise.

Why `SliverList` instead of `SliverAnimatedList`? Simply because `SliverAnimatedList's` `findChildIndexCallback` appears to be broken. 

Only functional difference that I'm aware of is that messages that disappear are no longer animated away. But this is a very rare and unusual scenario (usually, deleted messages are replaced with a placeholder rather than just "disappear")

You can see an example below with:
- Retained state while a message is in view
- Retained state for a messages out of view if KeepAlive is requested
- Animation of new messages as before (hard to see in the low fps gif, slow motion below, or compile the linked example code)

![Record_example_20220731161042](https://user-images.githubusercontent.com/44302748/182013042-6c73511e-2118-4f1f-b762-ade4e5a6048c.gif)

Example code: https://github.com/otto-dev/flutter_chat_ui/blob/example/example/lib/main.dart

Slow motion:
![Record_example_20220731163541](https://user-images.githubusercontent.com/44302748/182013436-ab68d4c0-86c2-46f9-b2c2-25c3d712f8e4.gif)

