### PR TITLE
Message state persistence with animated list

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,9 @@
-import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:http/http.dart' as http;
@@ -36,28 +37,11 @@ class ChatPage extends StatefulWidget {
 class _ChatPageState extends State<ChatPage> {
   List<types.Message> _messages = [];
   final _user = const types.User(id: '82091008-a484-4a89-ae75-a22bf8d6f3ac');
-  late Timer timer;
-  int counter = 0;
 
   @override
   void initState() {
-    timer = Timer.periodic(const Duration(seconds: 5), (_) {
-      final textMessage = types.CustomMessage(
-        author: _user,
-        metadata: {"index": counter++},
-        createdAt: DateTime.now().millisecondsSinceEpoch,
-        id: const Uuid().v4(),
-      );
-      _addMessage(textMessage);
-    });
     super.initState();
     _loadMessages();
-  }
-
-  @override
-  void dispose() {
-    timer.cancel();
-    super.dispose();
   }
 
   @override
@@ -71,13 +55,6 @@ class _ChatPageState extends State<ChatPage> {
           showUserAvatars: true,
           showUserNames: true,
           user: _user,
-          customMessageBuilder: (message, {required int messageWidth}) =>
-              _CustomMessage(
-            index: message.metadata!['index'],
-            onTap: () => setState(
-              () => _messages.removeWhere((element) => element == message),
-            ),
-          ),
         ),
       );
 
@@ -247,64 +224,13 @@ class _ChatPageState extends State<ChatPage> {
   }
 
   void _loadMessages() async {
-    // final response = await rootBundle.loadString('assets/messages.json');
-    // final messages = (jsonDecode(response) as List)
-    //     .map((e) => types.Message.fromJson(e as Map<String, dynamic>))
-    //     .toList();
-    //
-    // setState(() {
-    //   _messages = messages;
-    // });
-  }
-}
+    final response = await rootBundle.loadString('assets/messages.json');
+    final messages = (jsonDecode(response) as List)
+        .map((e) => types.Message.fromJson(e as Map<String, dynamic>))
+        .toList();
 
-class _CustomMessage extends StatefulWidget {
-  final int index;
-  final void Function() onTap;
-
-  const _CustomMessage({Key? key, required this.index, required this.onTap})
-      : super(key: key);
-
-  @override
-  _CustomMessageState createState() => _CustomMessageState();
-}
-
-class _CustomMessageState extends State<_CustomMessage>
-    with AutomaticKeepAliveClientMixin {
-  late Timer timer;
-  int counter = 0;
-
-  @override
-  void initState() {
-    timer = Timer.periodic(const Duration(milliseconds: 300), (_) {
-      setState(() {
-        counter++;
-      });
+    setState(() {
+      _messages = messages;
     });
-    super.initState();
   }
-
-  @override
-  void dispose() {
-    timer.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: widget.onTap,
-      child: Container(
-        padding: const EdgeInsets.all(8),
-        color: Colors.blue,
-        child: Text(
-          '#${widget.index}${wantKeepAlive ? ' keepAlive' : ''} - Counter: $counter',
-          style: Theme.of(context).textTheme.headline6,
-        ),
-      ),
-    );
-  }
-
-  @override
-  bool get wantKeepAlive => widget.index % 2 == 0;
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,8 @@
-import 'dart:convert';
+import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:http/http.dart' as http;
@@ -37,11 +36,28 @@ class ChatPage extends StatefulWidget {
 class _ChatPageState extends State<ChatPage> {
   List<types.Message> _messages = [];
   final _user = const types.User(id: '82091008-a484-4a89-ae75-a22bf8d6f3ac');
+  late Timer timer;
+  int counter = 0;
 
   @override
   void initState() {
+    timer = Timer.periodic(const Duration(seconds: 5), (_) {
+      final textMessage = types.CustomMessage(
+        author: _user,
+        metadata: {"index": counter++},
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+        id: const Uuid().v4(),
+      );
+      _addMessage(textMessage);
+    });
     super.initState();
     _loadMessages();
+  }
+
+  @override
+  void dispose() {
+    timer.cancel();
+    super.dispose();
   }
 
   @override
@@ -55,6 +71,13 @@ class _ChatPageState extends State<ChatPage> {
           showUserAvatars: true,
           showUserNames: true,
           user: _user,
+          customMessageBuilder: (message, {required int messageWidth}) =>
+              _CustomMessage(
+            index: message.metadata!['index'],
+            onTap: () => setState(
+              () => _messages.removeWhere((element) => element == message),
+            ),
+          ),
         ),
       );
 
@@ -224,13 +247,64 @@ class _ChatPageState extends State<ChatPage> {
   }
 
   void _loadMessages() async {
-    final response = await rootBundle.loadString('assets/messages.json');
-    final messages = (jsonDecode(response) as List)
-        .map((e) => types.Message.fromJson(e as Map<String, dynamic>))
-        .toList();
-
-    setState(() {
-      _messages = messages;
-    });
+    // final response = await rootBundle.loadString('assets/messages.json');
+    // final messages = (jsonDecode(response) as List)
+    //     .map((e) => types.Message.fromJson(e as Map<String, dynamic>))
+    //     .toList();
+    //
+    // setState(() {
+    //   _messages = messages;
+    // });
   }
+}
+
+class _CustomMessage extends StatefulWidget {
+  final int index;
+  final void Function() onTap;
+
+  const _CustomMessage({Key? key, required this.index, required this.onTap})
+      : super(key: key);
+
+  @override
+  _CustomMessageState createState() => _CustomMessageState();
+}
+
+class _CustomMessageState extends State<_CustomMessage>
+    with AutomaticKeepAliveClientMixin {
+  late Timer timer;
+  int counter = 0;
+
+  @override
+  void initState() {
+    timer = Timer.periodic(const Duration(milliseconds: 300), (_) {
+      setState(() {
+        counter++;
+      });
+    });
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: widget.onTap,
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        color: Colors.blue,
+        child: Text(
+          '#${widget.index}${wantKeepAlive ? ' keepAlive' : ''} - Counter: $counter',
+          style: Theme.of(context).textTheme.headline6,
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool get wantKeepAlive => widget.index % 2 == 0;
 }

--- a/lib/src/widgets/patched_sliver_animated_list.dart
+++ b/lib/src/widgets/patched_sliver_animated_list.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+
+
+/// NOTE: See here for an explanation of the fix:
+/// https://github.com/flutter/flutter/pull/108710
+/// Remove this file and replace with the upstream version once the fix is merged.
+
+
+
+/// Signature for the builder callback used by [AnimatedList].
+typedef AnimatedListItemBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
+
+/// Signature for the builder callback used by [AnimatedListState.removeItem].
+typedef AnimatedListRemovedItemBuilder = Widget Function(BuildContext context, Animation<double> animation);
+
+// The default insert/remove animation duration.
+const Duration _kDuration = Duration(milliseconds: 300);
+
+// Incoming and outgoing AnimatedList items.
+class _ActiveItem implements Comparable<_ActiveItem> {
+  _ActiveItem.incoming(this.controller, this.itemIndex) : removedItemBuilder = null;
+  _ActiveItem.outgoing(this.controller, this.itemIndex, this.removedItemBuilder);
+  _ActiveItem.index(this.itemIndex)
+      : controller = null,
+        removedItemBuilder = null;
+
+  final AnimationController? controller;
+  final AnimatedListRemovedItemBuilder? removedItemBuilder;
+  int itemIndex;
+
+  @override
+  int compareTo(_ActiveItem other) => itemIndex - other.itemIndex;
+}
+/// A sliver that animates items when they are inserted or removed.
+///
+/// This widget's [PatchedSliverAnimatedListState] can be used to dynamically insert or
+/// remove items. To refer to the [PatchedSliverAnimatedListState] either provide a
+/// [GlobalKey] or use the static [PatchedSliverAnimatedList.of] method from an item's
+/// input callback.
+///
+/// {@tool dartpad}
+/// This sample application uses a [PatchedSliverAnimatedList] to create an animated
+/// effect when items are removed or added to the list.
+///
+/// ** See code in examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [SliverList], which does not animate items when they are inserted or
+///    removed.
+///  * [AnimatedList], a non-sliver scrolling container that animates items when
+///    they are inserted or removed.
+class PatchedSliverAnimatedList extends StatefulWidget {
+  /// Creates a sliver that animates items when they are inserted or removed.
+  const PatchedSliverAnimatedList({
+    Key? key,
+    required this.itemBuilder,
+    this.findChildIndexCallback,
+    this.initialItemCount = 0,
+  }) : assert(itemBuilder != null),
+        assert(initialItemCount != null && initialItemCount >= 0),
+        super(key: key);
+
+  /// Called, as needed, to build list item widgets.
+  ///
+  /// List items are only built when they're scrolled into view.
+  ///
+  /// The [AnimatedListItemBuilder] index parameter indicates the item's
+  /// position in the list. The value of the index parameter will be between 0
+  /// and [initialItemCount] plus the total number of items that have been
+  /// inserted with [PatchedSliverAnimatedListState.insertItem] and less the total
+  /// number of items that have been removed with
+  /// [PatchedSliverAnimatedListState.removeItem].
+  ///
+  /// Implementations of this callback should assume that
+  /// [PatchedSliverAnimatedListState.removeItem] removes an item immediately.
+  final AnimatedListItemBuilder itemBuilder;
+
+  /// {@macro flutter.widgets.SliverChildBuilderDelegate.findChildIndexCallback}
+  final ChildIndexGetter? findChildIndexCallback;
+
+  /// {@macro flutter.widgets.animatedList.initialItemCount}
+  final int initialItemCount;
+
+  @override
+  PatchedSliverAnimatedListState createState() => PatchedSliverAnimatedListState();
+}
+
+class PatchedSliverAnimatedListState extends State<PatchedSliverAnimatedList> with TickerProviderStateMixin {
+
+  final List<_ActiveItem> _incomingItems = <_ActiveItem>[];
+  final List<_ActiveItem> _outgoingItems = <_ActiveItem>[];
+  int _itemsCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsCount = widget.initialItemCount;
+  }
+
+  @override
+  void dispose() {
+    for (final _ActiveItem item in _incomingItems.followedBy(_outgoingItems)) {
+      item.controller!.dispose();
+    }
+    super.dispose();
+  }
+
+  _ActiveItem? _removeActiveItemAt(List<_ActiveItem> items, int itemIndex) {
+    final int i = binarySearch(items, _ActiveItem.index(itemIndex));
+    return i == -1 ? null : items.removeAt(i);
+  }
+
+  _ActiveItem? _activeItemAt(List<_ActiveItem> items, int itemIndex) {
+    final int i = binarySearch(items, _ActiveItem.index(itemIndex));
+    return i == -1 ? null : items[i];
+  }
+
+  // The insertItem() and removeItem() index parameters are defined as if the
+  // removeItem() operation removed the corresponding list entry immediately.
+  // The entry is only actually removed from the ListView when the remove animation
+  // finishes. The entry is added to _outgoingItems when removeItem is called
+  // and removed from _outgoingItems when the remove animation finishes.
+
+  int _indexToItemIndex(int index) {
+    int itemIndex = index;
+    for (final _ActiveItem item in _outgoingItems) {
+      if (item.itemIndex <= itemIndex)
+        itemIndex += 1;
+      else
+        break;
+    }
+    return itemIndex;
+  }
+
+  int _itemIndexToIndex(int itemIndex) {
+    int index = itemIndex;
+    for (final _ActiveItem item in _outgoingItems) {
+      assert(item.itemIndex != itemIndex);
+      if (item.itemIndex < itemIndex)
+        index -= 1;
+      else
+        break;
+    }
+    return index;
+  }
+
+  SliverChildDelegate _createDelegate() {
+    return SliverChildBuilderDelegate(
+      _itemBuilder,
+      childCount: _itemsCount,
+      findChildIndexCallback: widget.findChildIndexCallback == null ? null : (Key key) {
+        final index = widget.findChildIndexCallback!(key);
+        return index != null ? _indexToItemIndex(index) : null;
+      },
+    );
+  }
+
+  /// Insert an item at [index] and start an animation that will be passed to
+  /// [PatchedSliverAnimatedList.itemBuilder] when the item is visible.
+  ///
+  /// This method's semantics are the same as Dart's [List.insert] method:
+  /// it increases the length of the list by one and shifts all items at or
+  /// after [index] towards the end of the list.
+  void insertItem(int index, { Duration duration = _kDuration }) {
+    assert(index != null && index >= 0);
+    assert(duration != null);
+
+    final int itemIndex = _indexToItemIndex(index);
+    assert(itemIndex >= 0 && itemIndex <= _itemsCount);
+
+    // Increment the incoming and outgoing item indices to account
+    // for the insertion.
+    for (final _ActiveItem item in _incomingItems) {
+      if (item.itemIndex >= itemIndex)
+        item.itemIndex += 1;
+    }
+    for (final _ActiveItem item in _outgoingItems) {
+      if (item.itemIndex >= itemIndex)
+        item.itemIndex += 1;
+    }
+
+    final AnimationController controller = AnimationController(
+      duration: duration,
+      vsync: this,
+    );
+    final _ActiveItem incomingItem = _ActiveItem.incoming(
+      controller,
+      itemIndex,
+    );
+    setState(() {
+      _incomingItems
+        ..add(incomingItem)
+        ..sort();
+      _itemsCount += 1;
+    });
+
+    controller.forward().then<void>((_) {
+      _removeActiveItemAt(_incomingItems, incomingItem.itemIndex)!.controller!.dispose();
+    });
+  }
+
+  /// Remove the item at [index] and start an animation that will be passed
+  /// to [builder] when the item is visible.
+  ///
+  /// Items are removed immediately. After an item has been removed, its index
+  /// will no longer be passed to the [PatchedSliverAnimatedList.itemBuilder]. However
+  /// the item will still appear in the list for [duration] and during that time
+  /// [builder] must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.remove] method:
+  /// it decreases the length of the list by one and shifts all items at or
+  /// before [index] towards the beginning of the list.
+  void removeItem(int index, AnimatedListRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    assert(index != null && index >= 0);
+    assert(builder != null);
+    assert(duration != null);
+
+    final int itemIndex = _indexToItemIndex(index);
+    assert(itemIndex >= 0 && itemIndex < _itemsCount);
+    assert(_activeItemAt(_outgoingItems, itemIndex) == null);
+
+    final _ActiveItem? incomingItem = _removeActiveItemAt(_incomingItems, itemIndex);
+    final AnimationController controller = incomingItem?.controller
+        ?? AnimationController(duration: duration, value: 1.0, vsync: this);
+    final _ActiveItem outgoingItem = _ActiveItem.outgoing(controller, itemIndex, builder);
+    setState(() {
+      _outgoingItems
+        ..add(outgoingItem)
+        ..sort();
+    });
+
+    controller.reverse().then<void>((void value) {
+      _removeActiveItemAt(_outgoingItems, outgoingItem.itemIndex)!.controller!.dispose();
+
+      // Decrement the incoming and outgoing item indices to account
+      // for the removal.
+      for (final _ActiveItem item in _incomingItems) {
+        if (item.itemIndex > outgoingItem.itemIndex)
+          item.itemIndex -= 1;
+      }
+      for (final _ActiveItem item in _outgoingItems) {
+        if (item.itemIndex > outgoingItem.itemIndex)
+          item.itemIndex -= 1;
+      }
+
+      setState(() => _itemsCount -= 1);
+    });
+  }
+
+  Widget _itemBuilder(BuildContext context, int itemIndex) {
+    final _ActiveItem? outgoingItem = _activeItemAt(_outgoingItems, itemIndex);
+    if (outgoingItem != null) {
+      return outgoingItem.removedItemBuilder!(
+        context,
+        outgoingItem.controller!.view,
+      );
+    }
+
+    final _ActiveItem? incomingItem = _activeItemAt(_incomingItems, itemIndex);
+    final Animation<double> animation = incomingItem?.controller?.view ?? kAlwaysCompleteAnimation;
+    return widget.itemBuilder(
+      context,
+      _itemIndexToIndex(itemIndex),
+      animation,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverList(
+      delegate: _createDelegate(),
+    );
+  }
+}


### PR DESCRIPTION
Same as https://github.com/flyerhq/flutter_chat_ui/pull/296 but using `SliverAnimatedList`, including animated deletions. Fixes #287.

Adds the upstream patch https://github.com/flutter/flutter/pull/108710 to this code-base, and uses it in the `ChatList` to retain state the state of message widgets. Unblocks progress on this area until the upstream patch is merged and a new flutter version released.