### PR TITLE
Extract text message text widget for previews

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -56,7 +56,6 @@ class Chat extends StatefulWidget {
     this.inputOptions = const InputOptions(),
     this.isAttachmentUploading,
     this.isLastPage,
-    this.isTextMessageTextSelectable = true,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.l10n = const ChatL10nEn(),
     required this.messages,
@@ -181,9 +180,6 @@ class Chat extends StatefulWidget {
 
   /// See [ChatList.isLastPage].
   final bool? isLastPage;
-
-  /// See [Message.isTextMessageTextSelectable].
-  final bool isTextMessageTextSelectable;
 
   /// See [ChatList.keyboardDismissBehavior].
   final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
@@ -516,7 +512,6 @@ class ChatState extends State<Chat> {
           fileMessageBuilder: widget.fileMessageBuilder,
           hideBackgroundOnEmojiMessages: widget.hideBackgroundOnEmojiMessages,
           imageMessageBuilder: widget.imageMessageBuilder,
-          isTextMessageTextSelectable: widget.isTextMessageTextSelectable,
           message: message,
           messageWidth: messageWidth,
           nameBuilder: widget.nameBuilder,

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -30,7 +30,6 @@ class Message extends StatelessWidget {
     this.fileMessageBuilder,
     required this.hideBackgroundOnEmojiMessages,
     this.imageMessageBuilder,
-    required this.isTextMessageTextSelectable,
     required this.message,
     required this.messageWidth,
     this.nameBuilder,
@@ -95,9 +94,6 @@ class Message extends StatelessWidget {
   /// Build an image message inside predefined bubble.
   final Widget Function(types.ImageMessage, {required int messageWidth})?
       imageMessageBuilder;
-
-  /// See [TextMessage.isTextMessageTextSelectable].
-  final bool isTextMessageTextSelectable;
 
   /// Any message type.
   final types.Message message;
@@ -348,7 +344,6 @@ class Message extends StatelessWidget {
             : TextMessage(
                 emojiEnlargementBehavior: emojiEnlargementBehavior,
                 hideBackgroundOnEmojiMessages: hideBackgroundOnEmojiMessages,
-                isTextMessageTextSelectable: isTextMessageTextSelectable,
                 message: textMessage,
                 nameBuilder: nameBuilder,
                 onPreviewDataFetched: onPreviewDataFetched,

--- a/lib/src/widgets/message/text_message.dart
+++ b/lib/src/widgets/message/text_message.dart
@@ -19,7 +19,6 @@ class TextMessage extends StatelessWidget {
     super.key,
     required this.emojiEnlargementBehavior,
     required this.hideBackgroundOnEmojiMessages,
-    required this.isTextMessageTextSelectable,
     required this.message,
     this.nameBuilder,
     this.onPreviewDataFetched,
@@ -34,9 +33,6 @@ class TextMessage extends StatelessWidget {
 
   /// See [Message.hideBackgroundOnEmojiMessages].
   final bool hideBackgroundOnEmojiMessages;
-
-  /// Whether user can tap and hold to select a text content.
-  final bool isTextMessageTextSelectable;
 
   /// [types.TextMessage].
   final types.TextMessage message;
@@ -162,118 +158,159 @@ class TextMessage extends StatelessWidget {
           nameBuilder?.call(message.author.id) ??
               UserName(author: message.author),
         if (enlargeEmojis)
-          if (isTextMessageTextSelectable)
+          if (options.isTextSelectable)
             SelectableText(message.text, style: emojiTextStyle)
           else
             Text(message.text, style: emojiTextStyle)
         else
-          ParsedText(
-            parse: [
-              MatchText(
-                onTap: (mail) async {
-                  final url = Uri(scheme: 'mailto', path: mail);
-                  if (await canLaunchUrl(url)) {
-                    await launchUrl(url);
-                  }
-                },
-                pattern: regexEmail,
-                style: bodyLinkTextStyle ??
-                    bodyTextStyle.copyWith(
-                      decoration: TextDecoration.underline,
-                    ),
-              ),
-              MatchText(
-                onTap: (urlText) async {
-                  final protocolIdentifierRegex = RegExp(
-                    r'^((http|ftp|https):\/\/)',
-                    caseSensitive: false,
-                  );
-                  if (!urlText.startsWith(protocolIdentifierRegex)) {
-                    urlText = 'https://$urlText';
-                  }
-                  if (options.onLinkPressed != null) {
-                    options.onLinkPressed!(urlText);
-                  } else {
-                    final url = Uri.tryParse(urlText);
-                    if (url != null && await canLaunchUrl(url)) {
-                      await launchUrl(
-                        url,
-                        mode: LaunchMode.externalApplication,
-                      );
-                    }
-                  }
-                },
-                pattern: regexLink,
-                style: bodyLinkTextStyle ??
-                    bodyTextStyle.copyWith(
-                      decoration: TextDecoration.underline,
-                    ),
-              ),
-              MatchText(
-                pattern: PatternStyle.bold.pattern,
-                style: boldTextStyle ??
-                    bodyTextStyle.merge(PatternStyle.bold.textStyle),
-                renderText: ({required String str, required String pattern}) =>
-                    {
-                  'display': str.replaceAll(
-                    PatternStyle.bold.from,
-                    PatternStyle.bold.replace,
-                  ),
-                },
-              ),
-              MatchText(
-                pattern: PatternStyle.italic.pattern,
-                style: bodyTextStyle.merge(PatternStyle.italic.textStyle),
-                renderText: ({required String str, required String pattern}) =>
-                    {
-                  'display': str.replaceAll(
-                    PatternStyle.italic.from,
-                    PatternStyle.italic.replace,
-                  ),
-                },
-              ),
-              MatchText(
-                pattern: PatternStyle.lineThrough.pattern,
-                style: bodyTextStyle.merge(PatternStyle.lineThrough.textStyle),
-                renderText: ({required String str, required String pattern}) =>
-                    {
-                  'display': str.replaceAll(
-                    PatternStyle.lineThrough.from,
-                    PatternStyle.lineThrough.replace,
-                  ),
-                },
-              ),
-              MatchText(
-                pattern: PatternStyle.code.pattern,
-                style: codeTextStyle ??
-                    bodyTextStyle.merge(PatternStyle.code.textStyle),
-                renderText: ({required String str, required String pattern}) =>
-                    {
-                  'display': str.replaceAll(
-                    PatternStyle.code.from,
-                    PatternStyle.code.replace,
-                  ),
-                },
-              ),
-            ],
-            regexOptions: const RegexOptions(multiLine: true, dotAll: true),
-            selectable: isTextMessageTextSelectable,
-            style: bodyTextStyle,
+          TextMessageText(
+            bodyLinkTextStyle: bodyLinkTextStyle,
+            bodyTextStyle: bodyTextStyle,
+            boldTextStyle: boldTextStyle,
+            codeTextStyle: codeTextStyle,
+            options: options,
             text: message.text,
-            textWidthBasis: TextWidthBasis.longestLine,
           ),
       ],
     );
   }
 }
 
+/// Widget to reuse the markdown capabilities, e.g., for previews.
+class TextMessageText extends StatelessWidget {
+  const TextMessageText({
+    super.key,
+    this.bodyLinkTextStyle,
+    this.boldTextStyle,
+    this.codeTextStyle,
+    required this.bodyTextStyle,
+    required this.options,
+    required this.text,
+  });
+
+  /// Style to apply to anything that matches a link.
+  final TextStyle? bodyLinkTextStyle;
+
+  /// Style to apply to anything that matches bold markdown.
+  final TextStyle? boldTextStyle;
+
+  /// Style to apply to anything that matches code markdown.
+  final TextStyle? codeTextStyle;
+
+  /// Regular style to use for any unmatched text. Also used as basis for the fallback options.
+  final TextStyle bodyTextStyle;
+
+  /// See [TextMessage.options].
+  final TextMessageOptions options;
+
+  /// Text that is shown as markdown.
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => ParsedText(
+        parse: [
+          MatchText(
+            onTap: (mail) async {
+              final url = Uri(scheme: 'mailto', path: mail);
+              if (await canLaunchUrl(url)) {
+                await launchUrl(url);
+              }
+            },
+            pattern: regexEmail,
+            style: bodyLinkTextStyle ??
+                bodyTextStyle.copyWith(
+                  decoration: TextDecoration.underline,
+                ),
+          ),
+          MatchText(
+            onTap: (urlText) async {
+              final protocolIdentifierRegex = RegExp(
+                r'^((http|ftp|https):\/\/)',
+                caseSensitive: false,
+              );
+              if (!urlText.startsWith(protocolIdentifierRegex)) {
+                urlText = 'https://$urlText';
+              }
+              if (options.onLinkPressed != null) {
+                options.onLinkPressed!(urlText);
+              } else {
+                final url = Uri.tryParse(urlText);
+                if (url != null && await canLaunchUrl(url)) {
+                  await launchUrl(
+                    url,
+                    mode: LaunchMode.externalApplication,
+                  );
+                }
+              }
+            },
+            pattern: regexLink,
+            style: bodyLinkTextStyle ??
+                bodyTextStyle.copyWith(
+                  decoration: TextDecoration.underline,
+                ),
+          ),
+          MatchText(
+            pattern: PatternStyle.bold.pattern,
+            style: boldTextStyle ??
+                bodyTextStyle.merge(PatternStyle.bold.textStyle),
+            renderText: ({required String str, required String pattern}) => {
+              'display': str.replaceAll(
+                PatternStyle.bold.from,
+                PatternStyle.bold.replace,
+              ),
+            },
+          ),
+          MatchText(
+            pattern: PatternStyle.italic.pattern,
+            style: bodyTextStyle.merge(PatternStyle.italic.textStyle),
+            renderText: ({required String str, required String pattern}) => {
+              'display': str.replaceAll(
+                PatternStyle.italic.from,
+                PatternStyle.italic.replace,
+              ),
+            },
+          ),
+          MatchText(
+            pattern: PatternStyle.lineThrough.pattern,
+            style: bodyTextStyle.merge(PatternStyle.lineThrough.textStyle),
+            renderText: ({required String str, required String pattern}) => {
+              'display': str.replaceAll(
+                PatternStyle.lineThrough.from,
+                PatternStyle.lineThrough.replace,
+              ),
+            },
+          ),
+          MatchText(
+            pattern: PatternStyle.code.pattern,
+            style: codeTextStyle ??
+                bodyTextStyle.merge(PatternStyle.code.textStyle),
+            renderText: ({required String str, required String pattern}) => {
+              'display': str.replaceAll(
+                PatternStyle.code.from,
+                PatternStyle.code.replace,
+              ),
+            },
+          ),
+        ],
+        regexOptions: const RegexOptions(multiLine: true, dotAll: true),
+        selectable: options.isTextSelectable,
+        style: bodyTextStyle,
+        text: text,
+        textWidthBasis: TextWidthBasis.longestLine,
+      );
+}
+
 @immutable
 class TextMessageOptions {
   const TextMessageOptions({
+    this.isTextSelectable = true,
     this.onLinkPressed,
     this.openOnPreviewImageTap = false,
     this.openOnPreviewTitleTap = false,
   });
+
+  /// Whether user can tap and hold to select a text content.
+  final bool isTextSelectable;
 
   /// Custom link press handler.
   final void Function(String)? onLinkPressed;

--- a/lib/src/widgets/message/text_message.dart
+++ b/lib/src/widgets/message/text_message.dart
@@ -184,7 +184,9 @@ class TextMessageText extends StatelessWidget {
     this.boldTextStyle,
     this.codeTextStyle,
     required this.bodyTextStyle,
-    required this.options,
+    this.maxLines,
+    this.options = const TextMessageOptions(),
+    this.overflow = TextOverflow.clip,
     required this.text,
   });
 
@@ -200,8 +202,14 @@ class TextMessageText extends StatelessWidget {
   /// Regular style to use for any unmatched text. Also used as basis for the fallback options.
   final TextStyle bodyTextStyle;
 
+  /// See [ParsedText.maxLines].
+  final int? maxLines;
+
   /// See [TextMessage.options].
   final TextMessageOptions options;
+
+  /// See [ParsedText.overflow].
+  final TextOverflow overflow;
 
   /// Text that is shown as markdown.
   final String text;
@@ -292,6 +300,8 @@ class TextMessageText extends StatelessWidget {
             },
           ),
         ],
+        maxLines: maxLines,
+        overflow: overflow,
         regexOptions: const RegexOptions(multiLine: true, dotAll: true),
         selectable: options.isTextSelectable,
         style: bodyTextStyle,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Extract `TextMessageText`
- Also move isSelectable into TextOptions

### Why is it needed?

- Makes the markdown capabilities more reusable e.g. for previews

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
