### PR TITLE
adds bottomWidget to ChatList

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -86,6 +86,7 @@ class Chat extends StatefulWidget {
     this.usePreviewData = true,
     required this.user,
     this.userAgent,
+    this.listBottomWidget,
   });
 
   /// See [Message.avatarBuilder].
@@ -288,6 +289,10 @@ class Chat extends StatefulWidget {
   /// See [Message.userAgent].
   final String? userAgent;
 
+  /// See [ChatList.bottomWidget].
+  /// For a custom chat input please use [customBottomWidget] instead.
+  final Widget? listBottomWidget;
+
   @override
   State<Chat> createState() => ChatState();
 }
@@ -406,6 +411,7 @@ class ChatState extends State<Chat> {
                                         widget.onEndReachedThreshold,
                                     scrollController: _scrollController,
                                     scrollPhysics: widget.scrollPhysics,
+                                    bottomWidget: widget.listBottomWidget,
                                   ),
                                 ),
                               ),

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -20,6 +20,7 @@ class ChatList extends StatefulWidget {
     this.onEndReachedThreshold,
     required this.scrollController,
     this.scrollPhysics,
+    this.bottomWidget,
   });
 
   /// Used for pagination (infinite scroll) together with [onEndReached].
@@ -53,6 +54,9 @@ class ChatList extends StatefulWidget {
 
   /// Determines the physics of the scroll view.
   final ScrollPhysics? scrollPhysics;
+
+  /// A custom widget at the bottom of the list.
+  final Widget? bottomWidget;
 
   @override
   State<ChatList> createState() => _ChatListState();
@@ -131,6 +135,8 @@ class _ChatListState extends State<ChatList>
           physics: widget.scrollPhysics,
           reverse: true,
           slivers: [
+            if (widget.bottomWidget != null)
+              SliverToBoxAdapter(child: widget.bottomWidget),
             SliverPadding(
               padding: const EdgeInsets.only(bottom: 4),
               sliver: PatchedSliverAnimatedList(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

I just added the ability to put a custom widget at the start of the `ChatList`.
This pull request is not breaking in any way, it just adds another parameter that has no effect on the behavior of the `Chat`.

### Why is it needed?

You can only add custom widgets to the list so far by implementing a custom message for it and then using the `customMessageBuilder`, which is relatively complicated.
