### PR TITLE
fixes unnecessary scrolls to the bottom

### DIFF
--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -264,7 +264,7 @@ class _ChatListState extends State<ChatList>
         final message = item['message']! as types.Message;
 
         // Compare items to fire only on newly added messages.
-        if (oldMessage != message) {
+        if (oldMessage.id != message.id) {
           // Run only for sent message.
           if (message.author.id == InheritedUser.of(context).user.id) {
             // Delay to give some time for Flutter to calculate new


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Chat now only scrolls to the new message if it is really new (different ID) and not if it has changed in any way.

### Why is it needed?

Until now, you are always sent to the beginning of the list if the first message in the chat has changed just a little. E.g. if the status of the message changes or if you slightly adjust other things afterwards (e.g. because you synchronize the message with the backend).
