### PR TITLE
Add ability to specify additional text matchers for text messages

### DIFF
--- a/lib/src/widgets/message/text_message.dart
+++ b/lib/src/widgets/message/text_message.dart
@@ -26,6 +26,7 @@ class TextMessage extends StatelessWidget {
     required this.showName,
     required this.usePreviewData,
     this.userAgent,
+    this.textMatchers = const [],
   });
 
   /// See [Message.emojiEnlargementBehavior].
@@ -56,6 +57,9 @@ class TextMessage extends StatelessWidget {
 
   /// User agent to fetch preview data with.
   final String? userAgent;
+
+  /// Additional matchers to parse the text.
+  final List<MatchText> textMatchers;
 
   @override
   Widget build(BuildContext context) {
@@ -170,6 +174,7 @@ class TextMessage extends StatelessWidget {
             codeTextStyle: codeTextStyle,
             options: options,
             text: message.text,
+            textMatchers: textMatchers,
           ),
       ],
     );
@@ -188,6 +193,7 @@ class TextMessageText extends StatelessWidget {
     this.options = const TextMessageOptions(),
     this.overflow = TextOverflow.clip,
     required this.text,
+    this.textMatchers = const [],
   });
 
   /// Style to apply to anything that matches a link.
@@ -214,9 +220,13 @@ class TextMessageText extends StatelessWidget {
   /// Text that is shown as markdown.
   final String text;
 
+  /// Additional matchers to parse the text.
+  final List<MatchText> textMatchers;
+
   @override
   Widget build(BuildContext context) => ParsedText(
         parse: [
+          ...textMatchers,
           MatchText(
             onTap: (mail) async {
               final url = Uri(scheme: 'mailto', path: mail);


### PR DESCRIPTION
### What does it do?

It adds a parameter to `TextMessage` to allow specifying additional text matchers.

### Why is it needed?

I need to display custom mentions in my text messages using widgets.
