### PR TITLE
Feature/audio message builder

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -54,6 +54,7 @@ class Chat extends StatefulWidget {
     ),
     this.imageHeaders,
     this.imageMessageBuilder,
+    this.audioMessageBuilder,
     this.inputOptions = const InputOptions(),
     this.isAttachmentUploading,
     this.isLastPage,
@@ -175,6 +176,10 @@ class Chat extends StatefulWidget {
   /// See [Message.imageMessageBuilder].
   final Widget Function(types.ImageMessage, {required int messageWidth})?
       imageMessageBuilder;
+
+  /// See [Message.audioMessageBuilder].
+  final Widget Function(types.AudioMessage, {required int messageWidth})?
+      audioMessageBuilder;
 
   /// See [Input.options].
   final InputOptions inputOptions;
@@ -518,6 +523,7 @@ class ChatState extends State<Chat> {
           hideBackgroundOnEmojiMessages: widget.hideBackgroundOnEmojiMessages,
           imageHeaders: widget.imageHeaders,
           imageMessageBuilder: widget.imageMessageBuilder,
+          audioMessageBuilder: widget.audioMessageBuilder,
           message: message,
           messageWidth: messageWidth,
           nameBuilder: widget.nameBuilder,

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -31,6 +31,7 @@ class Message extends StatelessWidget {
     required this.hideBackgroundOnEmojiMessages,
     this.imageHeaders,
     this.imageMessageBuilder,
+    this.audioMessageBuilder,
     required this.message,
     required this.messageWidth,
     this.nameBuilder,
@@ -98,6 +99,10 @@ class Message extends StatelessWidget {
   /// Build an image message inside predefined bubble.
   final Widget Function(types.ImageMessage, {required int messageWidth})?
       imageMessageBuilder;
+
+  /// Build an audio message.
+  final Widget Function(types.AudioMessage, {required int messageWidth})?
+      audioMessageBuilder;
 
   /// Any message type.
   final types.Message message;
@@ -361,6 +366,11 @@ class Message extends StatelessWidget {
                 usePreviewData: usePreviewData,
                 userAgent: userAgent,
               );
+      case types.MessageType.audio:
+        final audioMessage = message as types.AudioMessage;
+        return audioMessageBuilder != null
+            ? audioMessageBuilder!(audioMessage, messageWidth: messageWidth)
+            : const SizedBox();
       default:
         return const SizedBox();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_chat_types: ^3.5.0
+  flutter_chat_types: ^3.6.0
   flutter_link_previewer: ^3.1.0
   flutter_parsed_text: ^2.2.1
   intl: ^0.17.0


### PR DESCRIPTION
Instead of discussing now for months we could just initially provide an option to override the audio message rendering. It has no default implementation yet and fits to the chat types pull request https://github.com/flyerhq/flutter_chat_types/pull/30 

At some point later a default implementation can be provided using a plugin concept.