### PR TITLE
Fix scroll to unread when no unread messages exist

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -376,10 +376,15 @@ class ChatState extends State<Chat> {
   }
 
   /// Scroll to the unread header.
-  void scrollToUnreadHeader() => _scrollController.scrollToIndex(
-        _autoScrollIndexById[_unreadHeaderId]!,
+  void scrollToUnreadHeader() {
+    final unreadHeaderIndex = _autoScrollIndexById[_unreadHeaderId];
+    if (unreadHeaderIndex != null){
+      _scrollController.scrollToIndex(
+        unreadHeaderIndex,
         duration: widget.scrollToUnreadOptions.scrollDuration,
       );
+    }
+  }
 
   /// Scroll to the message with the specified [id].
   void scrollToMessage(String id, {Duration? duration}) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Check if the unread header exists before trying to scroll to it. Previously settting `scrollOnOpen: true` when there were no unread messages led to a null check error.

### Why is it needed?

Stop throwing errors.