### PR TITLE
Add "keyboardType" to the InputOptions

### DIFF
--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -202,7 +202,7 @@ class _InputState extends State<Input> {
                                 InheritedL10n.of(context).l10n.inputPlaceholder,
                           ),
                       focusNode: _inputFocusNode,
-                      keyboardType: TextInputType.multiline,
+                      keyboardType: widget.options.keyboardType,
                       maxLines: 5,
                       minLines: 1,
                       onChanged: widget.options.onTextChanged,
@@ -244,6 +244,7 @@ class _InputState extends State<Input> {
 class InputOptions {
   const InputOptions({
     this.inputClearMode = InputClearMode.always,
+    this.keyboardType = TextInputType.multiline,
     this.onTextChanged,
     this.onTextFieldTap,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
@@ -252,6 +253,9 @@ class InputOptions {
 
   /// Controls the [Input] clear behavior. Defaults to [InputClearMode.always].
   final InputClearMode inputClearMode;
+  
+  /// Controls the [Input] keyboard type. Defaults to [TextInputType.multiline].
+  final TextInputType keyboardType;
 
   /// Will be called whenever the text inside [TextField] changes.
   final void Function(String)? onTextChanged;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add an ability to control a text input field's keyboard type (multiline/number/email/etc.)

### Why is it needed?

Sometimes developers need to pre-define an input keyboard type to a specific type. For example, a user should only type numbers in a quiz game. 

### How to test it?

N/A

### Related issues/PRs

N/A
