### PR TITLE
Make the nameBuilder use the User not string

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -218,7 +218,7 @@ class Chat extends StatefulWidget {
   final List<types.Message> messages;
 
   /// See [Message.nameBuilder].
-  final Widget Function(String userId)? nameBuilder;
+  final Widget Function(types.User)? nameBuilder;
 
   /// See [Input.onAttachmentPressed].
   final VoidCallback? onAttachmentPressed;

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -111,7 +111,7 @@ class Message extends StatelessWidget {
   final int messageWidth;
 
   /// See [TextMessage.nameBuilder].
-  final Widget Function(String userId)? nameBuilder;
+  final Widget Function(types.User)? nameBuilder;
 
   /// See [UserAvatar.onAvatarTap].
   final void Function(types.User)? onAvatarTap;

--- a/lib/src/widgets/message/text_message.dart
+++ b/lib/src/widgets/message/text_message.dart
@@ -39,7 +39,7 @@ class TextMessage extends StatelessWidget {
 
   /// This is to allow custom user name builder
   /// By using this we can fetch newest user info based on id
-  final Widget Function(String userId)? nameBuilder;
+  final Widget Function(types.User)? nameBuilder;
 
   /// See [LinkPreview.onPreviewDataFetched].
   final void Function(types.TextMessage, types.PreviewData)?
@@ -155,7 +155,7 @@ class TextMessage extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (showName)
-          nameBuilder?.call(message.author.id) ??
+          nameBuilder?.call(message.author) ??
               UserName(author: message.author),
         if (enlargeEmojis)
           if (options.isTextSelectable)


### PR DESCRIPTION
### What does it do?

Instead of passing just user id to the `nameBuilder` let's pass whole `types.User` object. The id itself is rather useless, as we cannot get the real name of the user in such case.

I fully understand it's a breaking change though.

### Why is it needed?

To enrich the `nameBuilder`. At the moment it's not possible to achieve as simple effect as:

```
nameBuilder: (w) => ExcludeSemantics(
        child: chat_ui.UserName(author: w),
)
```

to render the name using default widget, but exclude it from the semantics tree.