### PR TITLE
added `autocorrect` and `enableSuggestions` props

### DIFF
--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -181,6 +181,8 @@ class _InputState extends State<Input> {
                   child: Padding(
                     padding: textPadding,
                     child: TextField(
+                      autocorrect: widget.options.autocorrect,
+                      enableSuggestions: widget.options.enableSuggestions,
                       controller: _textController,
                       cursorColor: InheritedChatTheme.of(context)
                           .theme
@@ -248,6 +250,8 @@ class InputOptions {
     this.onTextFieldTap,
     this.sendButtonVisibilityMode = SendButtonVisibilityMode.editing,
     this.textEditingController,
+    this.autocorrect = true,
+    this.enableSuggestions = true,
   });
 
   /// Controls the [Input] clear behavior. Defaults to [InputClearMode.always].
@@ -271,4 +275,10 @@ class InputOptions {
   /// you can create your own [InputTextFieldController] (imported from this lib)
   /// and pass it here.
   final TextEditingController? textEditingController;
+
+  /// [TextField] property to manage auto correct.
+  final bool autocorrect;
+
+  /// [TextField] property to manage auto suggestions.
+  final bool enableSuggestions;
 }

--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -181,6 +181,7 @@ class _InputState extends State<Input> {
                   child: Padding(
                     padding: textPadding,
                     child: TextField(
+                      enabled: widget.options.enabled,
                       autocorrect: widget.options.autocorrect,
                       enableSuggestions: widget.options.enableSuggestions,
                       controller: _textController,
@@ -252,6 +253,7 @@ class InputOptions {
     this.textEditingController,
     this.autocorrect = true,
     this.enableSuggestions = true,
+    this.enabled = true,
   });
 
   /// Controls the [Input] clear behavior. Defaults to [InputClearMode.always].
@@ -276,9 +278,12 @@ class InputOptions {
   /// and pass it here.
   final TextEditingController? textEditingController;
 
-  /// [TextField] property to manage auto correct.
+  /// Controls the [TextInput] autocorrect behavior. Defaults to [true].
   final bool autocorrect;
 
-  /// [TextField] property to manage auto suggestions.
+  /// Controls the [TextInput] enableSuggestions behavior. Defaults to [true].
   final bool enableSuggestions;
+
+  /// Controls the [TextInput] enabled behavior. Defaults to [true].
+  final bool enabled;
 }


### PR DESCRIPTION
### What does it do?

added `autocorrect` and `enableSuggestions` props for `InputOptions`. By default, both values will be `true`.

### Why is it needed?

Fixes https://github.com/flyerhq/flutter_chat_ui/issues/355

### How to test it?

You can now use the `autocorrect` and `enableSuggestions` props for `InputOptions`

### Related issues/PRs

https://github.com/flyerhq/flutter_chat_ui/issues/355
