### PR TITLE
Fixed repaint if type indicator don't use

### DIFF
--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -269,14 +269,15 @@ class _ChatListState extends State<ChatList>
             SliverPadding(
               padding: const EdgeInsets.only(bottom: 4),
               sliver: SliverToBoxAdapter(
-                child: widget.typingIndicatorOptions?.customTypingIndicator ??
-                    TypingIndicator(
-                      bubbleAlignment: widget.bubbleRtlAlignment,
-                      options: widget.typingIndicatorOptions!,
-                      showIndicator: (widget
-                              .typingIndicatorOptions!.typingUsers.isNotEmpty &&
-                          !_indicatorOnScrollStatus),
-                    ),
+                child: (widget.typingIndicatorOptions!.typingUsers.isNotEmpty && !_indicatorOnScrollStatus)
+                    ? widget.typingIndicatorOptions?.customTypingIndicator ??
+                        TypingIndicator(
+                          bubbleAlignment: widget.bubbleRtlAlignment,
+                          options: widget.typingIndicatorOptions!,
+                          showIndicator:
+                              (widget.typingIndicatorOptions!.typingUsers.isNotEmpty && !_indicatorOnScrollStatus),
+                        )
+                    : const SizedBox.shrink(),
               ),
             ),
             SliverPadding(


### PR DESCRIPTION
#449 issue

### What does it do?

This PR remove type indicator widget from tree when it is not show

### Why is it needed?

We prevent render type_indicator widget when on don't use

### How to test it?

You can open example screen, and open dev tools performance

### Related issues/PRs

[Let us know if this is related to any issue/pull request.](https://github.com/flyerhq/flutter_chat_ui/issues/449)
