### PR TITLE
Add Semantics to Send Button

### DIFF
--- a/lib/src/widgets/input/send_button.dart
+++ b/lib/src/widgets/input/send_button.dart
@@ -22,21 +22,24 @@ class SendButton extends StatelessWidget {
   Widget build(BuildContext context) => Container(
         margin: InheritedChatTheme.of(context).theme.sendButtonMargin ??
             const EdgeInsetsDirectional.fromSTEB(0, 0, 8, 0),
-        child: IconButton(
-          constraints: const BoxConstraints(
-            minHeight: 24,
-            minWidth: 24,
+        child: Semantics(
+          label: InheritedL10n.of(context).l10n.sendButtonAccessibilityLabel,
+          child: IconButton(
+            constraints: const BoxConstraints(
+              minHeight: 24,
+              minWidth: 24,
+            ),
+            icon: InheritedChatTheme.of(context).theme.sendButtonIcon ??
+                Image.asset(
+                  'assets/icon-send.png',
+                  color: InheritedChatTheme.of(context).theme.inputTextColor,
+                  package: 'flutter_chat_ui',
+                ),
+            onPressed: onPressed,
+            padding: padding,
+            splashRadius: 24,
+            tooltip: InheritedL10n.of(context).l10n.sendButtonAccessibilityLabel,
           ),
-          icon: InheritedChatTheme.of(context).theme.sendButtonIcon ??
-              Image.asset(
-                'assets/icon-send.png',
-                color: InheritedChatTheme.of(context).theme.inputTextColor,
-                package: 'flutter_chat_ui',
-              ),
-          onPressed: onPressed,
-          padding: padding,
-          splashRadius: 24,
-          tooltip: InheritedL10n.of(context).l10n.sendButtonAccessibilityLabel,
         ),
       );
 }


### PR DESCRIPTION
### What does it do?

Add a [Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html) around a SendButton.
It is different from a "tooltip", Tooltip ads a visual help on the long press, but this adds additional metadata to a Widget.

### Why is it needed?

Better support for accessibility
But personally, I need it because of [maestro](https://maestro.mobile.dev/platform-support/flutter). It will allow for the button to be located.

### How to test it?

No change in behaviour.

From UIAutomatorViewer (android only)
Before:
<img width="1562" alt="image" src="https://github.com/flyerhq/flutter_chat_ui/assets/1414810/4a9a7dce-cbc5-4106-817a-3979f441faf0">
After: 

<img width="1561" alt="Screenshot 2023-07-21 at 01 14 34" src="https://github.com/flyerhq/flutter_chat_ui/assets/1414810/17cf7447-883c-4d6e-9a13-c4799d36c49d">

Notice the `content-desc` property.

### Related issues/PRs

No existing issue
