### PR TITLE
added theming options for text input

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -67,6 +67,8 @@ abstract class ChatTheme {
     required this.errorColor,
     required this.errorIcon,
     required this.inputBackgroundColor,
+    required this.inputSurfaceTintColor,
+    required this.inputElevation,
     required this.inputBorderRadius,
     this.inputContainerDecoration,
     required this.inputMargin,
@@ -144,6 +146,11 @@ abstract class ChatTheme {
 
   /// Color of the bottom bar where text field is.
   final Color inputBackgroundColor;
+
+  /// Surface Tint Color of the bottom bar where text field is.
+  final Color inputSurfaceTintColor;
+
+  final double inputElevation;
 
   /// Top border radius of the bottom bar where text field is.
   final BorderRadius inputBorderRadius;
@@ -322,6 +329,8 @@ class DefaultChatTheme extends ChatTheme {
     super.errorColor = error,
     super.errorIcon,
     super.inputBackgroundColor = neutral0,
+    super.inputSurfaceTintColor = neutral0,
+    super.inputElevation = 0,
     super.inputBorderRadius = const BorderRadius.vertical(
       top: Radius.circular(20),
     ),
@@ -491,6 +500,8 @@ class DarkChatTheme extends ChatTheme {
     super.errorColor = error,
     super.errorIcon,
     super.inputBackgroundColor = secondaryDark,
+    super.inputSurfaceTintColor = secondaryDark,
+    super.inputElevation = 0,
     super.inputBorderRadius = const BorderRadius.vertical(
       top: Radius.circular(20),
     ),

--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -142,6 +142,9 @@ class _InputState extends State<Input> {
         child: Material(
           borderRadius: InheritedChatTheme.of(context).theme.inputBorderRadius,
           color: InheritedChatTheme.of(context).theme.inputBackgroundColor,
+          surfaceTintColor:
+              InheritedChatTheme.of(context).theme.inputSurfaceTintColor,
+          elevation: InheritedChatTheme.of(context).theme.inputElevation,
           child: Container(
             decoration:
                 InheritedChatTheme.of(context).theme.inputContainerDecoration,


### PR DESCRIPTION
Added two new theming variables to define an elevation and surface tint color for the input widget.

This allows to highlight the input text slightly, in line with the material ui guidlines.