### PR TITLE
Add mounted check before animation

### DIFF
--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -247,12 +247,15 @@ class _ChatListState extends State<ChatList>
             });
 
             widget.onEndReached!().whenComplete(() {
-              _controller.duration = const Duration(milliseconds: 300);
-              _controller.reverse();
+              if (mounted){
+                _controller.duration = const Duration(milliseconds: 300);
+                _controller.reverse();
+              
 
-              setState(() {
-                _isNextPageLoading = false;
-              });
+                setState(() {
+                  _isNextPageLoading = false;
+                });
+              }
             });
           }
 


### PR DESCRIPTION
Prevent an exception 
`AnimationController methods should not be used after calling dispose.` 
While user pop out the chat while animation is in progress

