### PR TITLE
Japanese input bug

### DIFF
--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
@@ -54,6 +55,9 @@ class _InputState extends State<Input> {
               PhysicalKeyboardKey.shiftRight,
             }.contains(el),
           )) {
+        if (kIsWeb && _textController.value.isComposingRangeValid) {
+          return KeyEventResult.ignored;
+        }
         if (event is KeyDownEvent) {
           _handleSendPressed();
         }

--- a/lib/src/widgets/input/input.dart
+++ b/lib/src/widgets/input/input.dart
@@ -107,6 +107,9 @@ class _InputState extends State<Input> {
   }
 
   void _handleTextControllerChange() {
+    if (_textController.value.isComposingRangeValid) {
+      return;
+    }
     setState(() {
       _sendButtonVisible = _textController.text.trim() != '';
     });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix bug related on convertible character input issue like Japanese.

### Why is it needed?
I think , some users who using CJK input are in trouble by this behavior.

### How to test it?

#### How to reproduce?
1. Build  example project of flutter_chat_ui with web browser.
2. Enter Japanese characters by Roman alphabets. for example, こんにちは(ko nn ni ti ha)
3. If you entered above characters, you can see  "kおんにちは" (#476 )
4. Press enter key once, then "kおんにちは" is sent as message, and "おんにちは" remains in text field.( #514)

My commit fix these issues.

### Related issues/PRs
#514 
#476
