### PR TITLE
#450 update: add message min width

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -80,6 +80,7 @@ abstract class ChatTheme {
     required this.messageBorderRadius,
     required this.messageInsetsHorizontal,
     required this.messageInsetsVertical,
+    required this.messageMinWidth,
     required this.primaryColor,
     required this.receivedEmojiMessageTextStyle,
     this.receivedMessageBodyBoldTextStyle,
@@ -185,6 +186,9 @@ abstract class ChatTheme {
 
   /// Vertical message bubble insets.
   final double messageInsetsVertical;
+
+  /// Message bubble min width. set to [double.infinity] adaptive screen.
+  final double messageMinWidth;
 
   /// Primary color of the chat used as a background of sent messages
   /// and statuses.
@@ -356,6 +360,7 @@ class DefaultChatTheme extends ChatTheme {
     super.messageBorderRadius = 20,
     super.messageInsetsHorizontal = 20,
     super.messageInsetsVertical = 16,
+    super.messageMinWidth = 440,
     super.primaryColor = primary,
     super.receivedEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     super.receivedMessageBodyBoldTextStyle,
@@ -528,6 +533,7 @@ class DarkChatTheme extends ChatTheme {
     super.messageBorderRadius = 20,
     super.messageInsetsHorizontal = 20,
     super.messageInsetsVertical = 16,
+    super.messageMinWidth = 440,
     super.primaryColor = primary,
     super.receivedEmojiMessageTextStyle = const TextStyle(fontSize: 40),
     super.receivedMessageBodyBoldTextStyle,

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -458,10 +458,11 @@ class ChatState extends State<Chat> {
         messageWidget = widget.systemMessageBuilder?.call(message) ??
             SystemMessage(message: message.text);
       } else {
+        final minWidth = widget.theme.messageMinWidth;
         final messageWidth =
             widget.showUserAvatars && message.author.id != widget.user.id
-                ? min(constraints.maxWidth * 0.72, 440).floor()
-                : min(constraints.maxWidth * 0.78, 440).floor();
+                ? min(constraints.maxWidth * 0.72, minWidth).floor()
+                : min(constraints.maxWidth * 0.78, minWidth).floor();
         final Widget msgWidget = Message(
           audioMessageBuilder: widget.audioMessageBuilder,
           avatarBuilder: widget.avatarBuilder,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?
add a messageMinWidth option in the chat theme configure

### Why is it needed?
if we run the App in macOS, the max message width is still 440.  looks very unusual.


Describe the issue you are solving.

### How to test it?
set messageMinWidth of the chat theme to [double. infinity] and run it on macOS.

### Related issues/PRs
https://github.com/flyerhq/flutter_chat_ui/issues/450