### PR TITLE
Fix README link to absolute path for pub.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 Flyer Chat is a platform for creating in-app chat experiences using Flutter or [React Native](https://github.com/flyerhq/react-native-chat-ui). This repository contains chat UI implementation for Flutter.
 
-* **Free, open-source and community-driven**. We offer no paid plugins and strive to create an easy-to-use, almost drop-in chat experience for any application. Contributions are more than welcome! Please read our [Contributing Guide](CONTRIBUTING.md).
+* **Free, open-source and community-driven**. We offer no paid plugins and strive to create an easy-to-use, almost drop-in chat experience for any application. Contributions are more than welcome! Please read our [Contributing Guide](https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md).
 
 * **Backend agnostic**. You can choose the backend you prefer. But if you don't have one, we provide our own free and open-source [Firebase implementation](https://pub.dev/packages/flutter_firebase_chat_core), which can be used to create a working chat in minutes. We are also working on our more advanced SaaS and self-hosted solutions.
 
@@ -62,12 +62,12 @@ Read our [documentation](https://docs.flyer.chat/flutter/chat-ui/) or see the [e
 
 ## Contributing
 
-Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a pull request to the project.
+Please read our [Contributing Guide](https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md) before submitting a pull request to the project.
 
 ## Code of Conduct
 
-Flyer Chat has adopted the [Contributor Covenant](https://www.contributor-covenant.org) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Flyer Chat has adopted the [Contributor Covenant](https://www.contributor-covenant.org) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](https://github.com/flyerhq/flutter_chat_ui/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0](LICENSE)
+Licensed under the [Apache License, Version 2.0](https://github.com/flyerhq/flutter_chat_ui/blob/main/LICENSE)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?
Hi, Thank you for your awesome project! I have a some correction for links in README.  

In [pub.dev docs](https://pub.dev/documentation/flutter_chat_ui/latest/), some relative path links are not working.
So, I've fixed them by changing absolute path links.
Thanks! ☺️

### Why is it needed?

For documentation usability.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
