### PR TITLE
Adds l10n for Persian language (fa locale).

### DIFF
--- a/lib/src/chat_l10n.dart
+++ b/lib/src/chat_l10n.dart
@@ -97,6 +97,19 @@ class ChatL10nEs extends ChatL10n {
   });
 }
 
+/// Persian l10n which extends [ChatL10n].
+@immutable
+class ChatL10nFa extends ChatL10n {
+  const ChatL10nFa({
+    super.attachmentButtonAccessibilityLabel = 'فرستادن رسانه',
+    super.emptyChatPlaceholder = 'هنوز پیامی وجود ندارد',
+    super.fileButtonAccessibilityLabel = 'فایل',
+    super.inputPlaceholder = 'متن پیام',
+    super.sendButtonAccessibilityLabel = 'بفرست',
+    super.unreadMessagesLabel = 'پیام‌های خوانده نشده',
+  });
+}
+
 /// Finnish l10n which extends [ChatL10n].
 @immutable
 class ChatL10nFi extends ChatL10n {


### PR DESCRIPTION
### What does it do?

Added i10n class for Persian language. The standard locale for Persian is `fa` and `fa-IR` is the most used one.

