### PR TITLE
Default bubbled message to the bubbleBuilder

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -116,6 +116,7 @@ class Chat extends StatefulWidget {
     Widget child, {
     required types.Message message,
     required bool nextMessageInGroup,
+    required Widget defaultBubbleMessage,
   })? bubbleBuilder;
 
   /// See [Message.bubbleRtlAlignment].

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -74,6 +74,7 @@ class Message extends StatelessWidget {
     Widget child, {
     required types.Message message,
     required bool nextMessageInGroup,
+    required Widget defaultBubbleMessage,
   })? bubbleBuilder;
 
   /// Determine the alignment of the bubble for RTL languages. Has no effect
@@ -205,28 +206,28 @@ class Message extends StatelessWidget {
     BorderRadius borderRadius,
     bool currentUserIsAuthor,
     bool enlargeEmojis,
-  ) =>
-      bubbleBuilder != null
-          ? bubbleBuilder!(
-              _messageBuilder(),
-              message: message,
-              nextMessageInGroup: roundBorder,
-            )
-          : enlargeEmojis && hideBackgroundOnEmojiMessages
-              ? _messageBuilder()
-              : Container(
-                  decoration: BoxDecoration(
-                    borderRadius: borderRadius,
-                    color: !currentUserIsAuthor ||
-                            message.type == types.MessageType.image
-                        ? InheritedChatTheme.of(context).theme.secondaryColor
-                        : InheritedChatTheme.of(context).theme.primaryColor,
-                  ),
-                  child: ClipRRect(
-                    borderRadius: borderRadius,
-                    child: _messageBuilder(),
-                  ),
-                );
+  ) {
+    Widget defaultMessage = (enlargeEmojis && hideBackgroundOnEmojiMessages)
+        ? _messageBuilder()
+        : Container(
+            decoration: BoxDecoration(
+              borderRadius: borderRadius,
+              color: !currentUserIsAuthor || message.type == types.MessageType.image ? InheritedChatTheme.of(context).theme.secondaryColor : InheritedChatTheme.of(context).theme.primaryColor,
+            ),
+            child: ClipRRect(
+              borderRadius: borderRadius,
+              child: _messageBuilder(),
+            ),
+          );
+    return bubbleBuilder != null
+        ? bubbleBuilder!(
+            _messageBuilder(),
+            message: message,
+            nextMessageInGroup: roundBorder,
+            defaultBubbleMessage: defaultMessage,
+          )
+        : defaultMessage;
+  }
 
   Widget _messageBuilder() {
     switch (message.type) {


### PR DESCRIPTION
### What does it do?

This adds the default message to the bubbleBuilder().  This way the developer can spit back out the nicely formatted message but wrap it with any other widgets they so decide to choose. 

### Why is it needed?

People want to add options and other functionallity to messages.  So we need to render stuff around the message.  

### How to test it?

Use the bubbleBuilder() method and make it return the default message.  If messages show up it's working fine.  Or return Text('blah') to see all of the messages are now "blah"

### Related issues/PRs

The issues this is addressing:
https://github.com/flyerhq/flutter_chat_ui/issues/552
https://github.com/flyerhq/flutter_chat_ui/issues/508
