### PR TITLE
Add support for AssetImage in IOConditional

### DIFF
--- a/lib/src/conditional/io_conditional.dart
+++ b/lib/src/conditional/io_conditional.dart
@@ -17,6 +17,8 @@ class IOConditional extends BaseConditional {
   ImageProvider getProvider(String uri, {Map<String, String>? headers}) {
     if (uri.startsWith('http')) {
       return NetworkImage(uri, headers: headers);
+    } else if (uri.startsWith('assets/')) {
+      return AssetImage(uri);
     } else {
       return FileImage(File(uri));
     }

--- a/lib/src/widgets/message/user_avatar.dart
+++ b/lib/src/widgets/message/user_avatar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import '../../models/bubble_rtl_alignment.dart';
 import '../../util.dart';
 import '../state/inherited_chat_theme.dart';
+import '../../conditional/conditional.dart';
 
 /// Renders user's avatar or initials next to a message.
 class UserAvatar extends StatelessWidget {
@@ -50,7 +51,10 @@ class UserAvatar extends StatelessWidget {
                   .userAvatarImageBackgroundColor
               : color,
           backgroundImage: hasImage
-              ? NetworkImage(author.imageUrl!, headers: imageHeaders)
+              ? Conditional().getProvider(
+                  author.imageUrl!,
+                  headers: imageHeaders,
+                )
               : null,
           radius: 16,
           child: !hasImage


### PR DESCRIPTION
## Description
This pull request adds support for AssetImage in the IOConditional class. This allows the package to correctly handle image assets from the Flutter assets directory.

## Problem
Currently, the package doesn't handle asset URIs correctly, causing errors when trying to display images from the assets folder.

## Solution
Modified the `getProvider` method in `IOConditional` to check for URIs starting with 'assets/' and use `AssetImage` for those cases.

## Impact
This change allows users to easily display images from their assets folder without encountering errors, improving the package's flexibility and ease of use.

## Testing
Tested with local asset images in a sample Flutter project. The images now display correctly in the chat UI.

Please review and let me know if any changes are needed.
