### PR TITLE
Update to set a custom value for the gap between message groups

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -111,6 +111,7 @@ List<Object> calculateChatMessages(
   bool dateIsUtc = false,
   String? dateLocale,
   required int groupMessagesThreshold,
+  double messagesSpacerHeight = 12,
   String? lastReadMessageId,
   required bool showUserNames,
   DateFormat? timeFormat,
@@ -217,7 +218,7 @@ List<Object> calculateChatMessages(
       chatMessages.insert(
         0,
         MessageSpacer(
-          height: 12,
+          height: messagesSpacerHeight,
           id: message.id,
         ),
       );

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -55,6 +55,7 @@ class Chat extends StatefulWidget {
     this.emptyState,
     this.fileMessageBuilder,
     this.groupMessagesThreshold = 60000,
+    this.messagesSpacerHeight = 12,
     this.hideBackgroundOnEmojiMessages = true,
     this.imageGalleryOptions = const ImageGalleryOptions(
       maxScale: PhotoViewComputedScale.covered,
@@ -175,6 +176,10 @@ class Chat extends StatefulWidget {
   /// Default value is 1 minute, 60000 ms. When time between two messages
   /// is lower than this threshold, they will be visually grouped.
   final int groupMessagesThreshold;
+
+  /// Height value of spacers added to separate message groups.
+  /// Default value is 12. If 0, no gap between groups.
+  final double messagesSpacerHeight;
 
   /// See [Message.hideBackgroundOnEmojiMessages].
   final bool hideBackgroundOnEmojiMessages;
@@ -594,6 +599,7 @@ class ChatState extends State<Chat> {
         lastReadMessageId: widget.scrollToUnreadOptions.lastReadMessageId,
         showUserNames: widget.showUserNames,
         timeFormat: widget.timeFormat,
+        messagesSpacerHeight: widget.messagesSpacerHeight,
       );
 
       _chatMessages = result[0] as List<Object>;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows developers to arbitrarily set the spacing between message groups

### Why is it needed?

Previously, the value was fixed at 12, making it impossible to set the value arbitrarily

### How to test it?

You can test this by simply setting the value in Chat as shown below
```dart
body: Chat(
    messagesSpacerHeight: 3,
    ~~~~~
)
```

### Related issues/PRs

None
