### PR TITLE
Add customization options for padding in chat area

### DIFF
--- a/lib/src/chat_theme.dart
+++ b/lib/src/chat_theme.dart
@@ -61,6 +61,7 @@ abstract class ChatTheme {
     required this.backgroundColor,
     this.bubbleMargin,
     required this.dateDividerMargin,
+    required this.chatContentMargin,
     required this.dateDividerTextStyle,
     required this.deliveredIcon,
     required this.documentIcon,
@@ -131,6 +132,9 @@ abstract class ChatTheme {
 
   /// Margin around date dividers.
   final EdgeInsets dateDividerMargin;
+
+  /// Margin inside chat area.
+  final EdgeInsets chatContentMargin;
 
   /// Text style of the date dividers.
   final TextStyle dateDividerTextStyle;
@@ -325,6 +329,9 @@ class DefaultChatTheme extends ChatTheme {
       bottom: 32,
       top: 16,
     ),
+    super.chatContentMargin = const EdgeInsets.only(
+      bottom: 4,
+    ),
     super.dateDividerTextStyle = const TextStyle(
       color: neutral2,
       fontSize: 12,
@@ -498,6 +505,9 @@ class DarkChatTheme extends ChatTheme {
     super.dateDividerMargin = const EdgeInsets.only(
       bottom: 32,
       top: 16,
+    ),
+    super.chatContentMargin = const EdgeInsets.only(
+      bottom: 4,
     ),
     super.dateDividerTextStyle = const TextStyle(
       color: neutral7,

--- a/lib/src/widgets/chat_list.dart
+++ b/lib/src/widgets/chat_list.dart
@@ -296,7 +296,7 @@ class _ChatListState extends State<ChatList>
               ),
             ),
             SliverPadding(
-              padding: const EdgeInsets.only(bottom: 4),
+              padding: InheritedChatTheme.of(context).theme.chatContentMargin,
               sliver: SliverAnimatedList(
                 findChildIndexCallback: (Key key) {
                   if (key is ValueKey<Object>) {


### PR DESCRIPTION
What does it do?
This PR adds a new parameter, chatContentPadding, which allows developers to customize the padding inside the chat content area. This provides more flexibility in controlling the spacing around the chat content within the chat container.

Why is it needed?
The current version of flutter_chat_ui does not offer a way to adjust the padding inside the chat content area. By adding this feature, developers can better match the chat UI to their specific design requirements, ensuring that the chat content aligns properly within different layouts.

How to test it?
To test the new chatContentPadding parameter:

Integrate the updated library into an existing Flutter project.
Use the chatContentPadding parameter in the Chat widget to set custom padding values.
Verify that the padding is applied correctly within the chat content area across various screen sizes and orientations.
