### PR TITLE
Custom unread header builder

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -144,7 +144,7 @@ class Chat extends StatefulWidget {
   /// Custom date header builder gives ability to customize date header widget.
   final Widget Function(DateHeader)? dateHeaderBuilder;
 
-// Custom unreadHeaderData spacer builder gives ability to customize header for unread messages.
+// Custom unread header data builder gives ability to customize header for unread messages.
   final Widget Function(UnreadHeaderData)? unreadHeaderDataBuilder;
 
   /// Time (in ms) between two messages when we will render a date header.
@@ -603,7 +603,7 @@ class ChatState extends State<Chat> {
         lastReadMessageId: widget.scrollToUnreadOptions.lastReadMessageId,
         showUserNames: widget.showUserNames,
         timeFormat: widget.timeFormat,
-        
+        messagesSpacerHeight: widget.messagesSpacerHeight,
       );
 
       _chatMessages = result[0] as List<Object>;

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -461,14 +461,15 @@ class ChatState extends State<Chat> {
         height: object.height,
       );
     } else if (object is UnreadHeaderData) {
-      return widget.unreadHeaderDataBuilder?.call(object) ?? AutoScrollTag(
-        controller: _scrollController,
-        index: index ?? -1,
-        key: const Key('unread_header'),
-        child:  UnreadHeader(
-          marginTop: object.marginTop,
-        ),
-      );
+      return widget.unreadHeaderDataBuilder?.call(object) ??
+          AutoScrollTag(
+            controller: _scrollController,
+            index: index ?? -1,
+            key: const Key('unread_header'),
+            child: UnreadHeader(
+              marginTop: object.marginTop,
+            ),
+          );
     } else {
       final map = object as Map<String, Object>;
       final message = map['message']! as types.Message;

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -104,6 +104,7 @@ class Chat extends StatefulWidget {
     this.slidableMessageBuilder,
     this.isLeftStatus = false,
     this.messageWidthRatio = 0.72,
+    this.unreadHeaderDataBuilder,
   });
 
   /// See [Message.audioMessageBuilder].
@@ -142,6 +143,9 @@ class Chat extends StatefulWidget {
 
   /// Custom date header builder gives ability to customize date header widget.
   final Widget Function(DateHeader)? dateHeaderBuilder;
+
+// Custom unreadHeaderData spacer builder gives ability to customize header for unread messages.
+  final Widget Function(UnreadHeaderData)? unreadHeaderDataBuilder;
 
   /// Time (in ms) between two messages when we will render a date header.
   /// Default value is 15 minutes, 900000 ms. When time between two messages
@@ -457,11 +461,11 @@ class ChatState extends State<Chat> {
         height: object.height,
       );
     } else if (object is UnreadHeaderData) {
-      return AutoScrollTag(
+      return widget.unreadHeaderDataBuilder?.call(object) ?? AutoScrollTag(
         controller: _scrollController,
         index: index ?? -1,
         key: const Key('unread_header'),
-        child: UnreadHeader(
+        child:  UnreadHeader(
           marginTop: object.marginTop,
         ),
       );
@@ -599,7 +603,7 @@ class ChatState extends State<Chat> {
         lastReadMessageId: widget.scrollToUnreadOptions.lastReadMessageId,
         showUserNames: widget.showUserNames,
         timeFormat: widget.timeFormat,
-        messagesSpacerHeight: widget.messagesSpacerHeight,
+        
       );
 
       _chatMessages = result[0] as List<Object>;


### PR DESCRIPTION
What does it do?
This PR implements a custom UnreadHeaderDataBuilder for the unread messages divider in the Flutter Chat UI library. It allows developers to customize the appearance and behavior of the unread messages separator, providing more flexibility in how unread messages are displayed in the chat interface.

Why is it needed?
The default unread messages divider may not meet the specific design requirements of all applications. This custom builder enables developers to tailor the unread message indicator to better fit their application's design and user experience needs.

How to test it?
To test this feature:

Integrate the updated Flutter Chat UI library into your project.
Implement the custom UnreadHeaderDataBuilder in your chat UI.
Verify that the unread messages divider displays as expected according to the custom builder's implementation.