### PR TITLE
Check first message

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -136,17 +136,16 @@ List<Object> calculateChatMessages(
     var nextMessageInGroup = false;
     var showName = false;
 
-    if (showUserNames) {
-      final previousMessage = isFirst ? null : messages[i + 1];
+    final previousMessage = isFirst ? null : messages[i + 1];
 
-      final isFirstInGroup = notMyMessage &&
-          ((message.author.id != previousMessage?.author.id) ||
-              (messageHasCreatedAt &&
-                  previousMessage?.createdAt != null &&
+    final isFirstInGroup = ((message.author.id != previousMessage?.author.id) ||
+        (messageHasCreatedAt &&
+            previousMessage?.createdAt != null &&
                   message.createdAt! - previousMessage!.createdAt! >
                       groupMessagesThreshold));
 
-      if (isFirstInGroup) {
+    if (showUserNames) {
+      if (isFirstInGroup && notMyMessage) {
         shouldShowName = false;
         if (message.type == types.MessageType.text) {
           showName = true;
@@ -210,6 +209,7 @@ List<Object> calculateChatMessages(
     chatMessages.insert(0, {
       'message': message,
       'nextMessageInGroup': nextMessageInGroup,
+      'isFirstInGroup': isFirstInGroup,
       'showName': notMyMessage && showUserNames && showName,
       'showStatus': message.showStatus ?? true,
     });

--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -118,6 +118,7 @@ class Chat extends StatefulWidget {
     Widget child, {
     required types.Message message,
     required bool nextMessageInGroup,
+    required bool isFirstInGroup,
   })? bubbleBuilder;
 
   /// See [Message.bubbleRtlAlignment].
@@ -517,6 +518,7 @@ class ChatState extends State<Chat> {
           onPreviewDataFetched: _onPreviewDataFetched,
           roundBorder: map['nextMessageInGroup'] == true,
           showAvatar: map['nextMessageInGroup'] == false,
+          isFirstInGroup: map['isFirstInGroup'] == true,
           showName: map['showName'] == true,
           showStatus: map['showStatus'] == true,
           isLeftStatus: widget.isLeftStatus,

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -45,6 +45,7 @@ class Message extends StatelessWidget {
     this.onMessageVisibilityChanged,
     this.onPreviewDataFetched,
     required this.roundBorder,
+    required this.isFirstInGroup,
     required this.showAvatar,
     required this.showName,
     required this.showStatus,
@@ -74,6 +75,7 @@ class Message extends StatelessWidget {
     Widget child, {
     required types.Message message,
     required bool nextMessageInGroup,
+    required bool isFirstInGroup,
   })? bubbleBuilder;
 
   /// Determine the alignment of the bubble for RTL languages. Has no effect
@@ -152,6 +154,8 @@ class Message extends StatelessWidget {
   /// Rounds border of the message to visually group messages together.
   final bool roundBorder;
 
+  final bool isFirstInGroup;
+
   /// Show user avatar for the received message. Useful for a group chat.
   final bool showAvatar;
 
@@ -226,6 +230,7 @@ class Message extends StatelessWidget {
             _messageBuilder(),
             message: message,
             nextMessageInGroup: roundBorder,
+            isFirstInGroup: isFirstInGroup,
           )
         : defaultMessage;
   }

--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -59,8 +59,7 @@ class Message extends StatelessWidget {
   });
 
   /// Build an audio message inside predefined bubble.
-  final Widget Function(types.AudioMessage, {required int messageWidth})?
-      audioMessageBuilder;
+  final Widget Function(types.AudioMessage, {required int messageWidth})? audioMessageBuilder;
 
   /// This is to allow custom user avatar builder
   /// By using this we can fetch newest user info based on id.
@@ -83,12 +82,10 @@ class Message extends StatelessWidget {
   final BubbleRtlAlignment? bubbleRtlAlignment;
 
   /// Build a custom message inside predefined bubble.
-  final Widget Function(types.CustomMessage, {required int messageWidth})?
-      customMessageBuilder;
+  final Widget Function(types.CustomMessage, {required int messageWidth})? customMessageBuilder;
 
   /// Build a custom status widgets.
-  final Widget Function(types.Message message, {required BuildContext context})?
-      customStatusBuilder;
+  final Widget Function(types.Message message, {required BuildContext context})? customStatusBuilder;
 
   /// Controls the enlargement behavior of the emojis in the
   /// [types.TextMessage].
@@ -96,8 +93,7 @@ class Message extends StatelessWidget {
   final EmojiEnlargementBehavior emojiEnlargementBehavior;
 
   /// Build a file message inside predefined bubble.
-  final Widget Function(types.FileMessage, {required int messageWidth})?
-      fileMessageBuilder;
+  final Widget Function(types.FileMessage, {required int messageWidth})? fileMessageBuilder;
 
   /// Hide background for messages containing only emojis.
   final bool hideBackgroundOnEmojiMessages;
@@ -106,8 +102,7 @@ class Message extends StatelessWidget {
   final Map<String, String>? imageHeaders;
 
   /// Build an image message inside predefined bubble.
-  final Widget Function(types.ImageMessage, {required int messageWidth})?
-      imageMessageBuilder;
+  final Widget Function(types.ImageMessage, {required int messageWidth})? imageMessageBuilder;
 
   /// See [Chat.imageProviderBuilder].
   final ImageProvider Function({
@@ -135,8 +130,7 @@ class Message extends StatelessWidget {
   final void Function(BuildContext context, types.Message)? onMessageLongPress;
 
   /// Called when user makes a long press on status icon in any message.
-  final void Function(BuildContext context, types.Message)?
-      onMessageStatusLongPress;
+  final void Function(BuildContext context, types.Message)? onMessageStatusLongPress;
 
   /// Called when user taps on status icon in any message.
   final void Function(BuildContext context, types.Message)? onMessageStatusTap;
@@ -148,12 +142,12 @@ class Message extends StatelessWidget {
   final void Function(types.Message, bool visible)? onMessageVisibilityChanged;
 
   /// See [TextMessage.onPreviewDataFetched].
-  final void Function(types.TextMessage, types.PreviewData)?
-      onPreviewDataFetched;
+  final void Function(types.TextMessage, types.PreviewData)? onPreviewDataFetched;
 
   /// Rounds border of the message to visually group messages together.
   final bool roundBorder;
 
+  /// This is used to determine if the message is the first in a group of messages or a single message.
   final bool isFirstInGroup;
 
   /// Show user avatar for the received message. Useful for a group chat.
@@ -191,8 +185,7 @@ class Message extends StatelessWidget {
   final String? userAgent;
 
   /// Build an audio message inside predefined bubble.
-  final Widget Function(types.VideoMessage, {required int messageWidth})?
-      videoMessageBuilder;
+  final Widget Function(types.VideoMessage, {required int messageWidth})? videoMessageBuilder;
 
   Widget _avatarBuilder() => showAvatar
       ? avatarBuilder?.call(message.author) ??
@@ -215,8 +208,7 @@ class Message extends StatelessWidget {
         : Container(
             decoration: BoxDecoration(
               borderRadius: borderRadius,
-              color: !currentUserIsAuthor ||
-                      message.type == types.MessageType.image
+              color: !currentUserIsAuthor || message.type == types.MessageType.image
                   ? InheritedChatTheme.of(context).theme.secondaryColor
                   : InheritedChatTheme.of(context).theme.primaryColor,
             ),
@@ -313,15 +305,13 @@ class Message extends StatelessWidget {
     final query = MediaQuery.of(context);
     final user = InheritedUser.of(context).user;
     final currentUserIsAuthor = user.id == message.author.id;
-    final enlargeEmojis =
-        emojiEnlargementBehavior != EmojiEnlargementBehavior.never &&
-            message is types.TextMessage &&
-            isConsistsOfEmojis(
-              emojiEnlargementBehavior,
-              message as types.TextMessage,
-            );
-    final messageBorderRadius =
-        InheritedChatTheme.of(context).theme.messageBorderRadius;
+    final enlargeEmojis = emojiEnlargementBehavior != EmojiEnlargementBehavior.never &&
+        message is types.TextMessage &&
+        isConsistsOfEmojis(
+          emojiEnlargementBehavior,
+          message as types.TextMessage,
+        );
+    final messageBorderRadius = InheritedChatTheme.of(context).theme.messageBorderRadius;
     final borderRadius = bubbleRtlAlignment == BubbleRtlAlignment.left
         ? BorderRadiusDirectional.only(
             bottomEnd: Radius.circular(
@@ -369,9 +359,7 @@ class Message extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         mainAxisSize: MainAxisSize.min,
-        textDirection: bubbleRtlAlignment == BubbleRtlAlignment.left
-            ? null
-            : TextDirection.ltr,
+        textDirection: bubbleRtlAlignment == BubbleRtlAlignment.left ? null : TextDirection.ltr,
         children: [
           if (!currentUserIsAuthor && showUserAvatars) _avatarBuilder(),
           if (currentUserIsAuthor && isLeftStatus) _statusIcon(context),
@@ -389,8 +377,7 @@ class Message extends StatelessWidget {
                   child: onMessageVisibilityChanged != null
                       ? VisibilityDetector(
                           key: Key(message.id),
-                          onVisibilityChanged: (visibilityInfo) =>
-                              onMessageVisibilityChanged!(
+                          onVisibilityChanged: (visibilityInfo) => onMessageVisibilityChanged!(
                             message,
                             visibilityInfo.visibleFraction > 0.1,
                           ),

--- a/test/util.test.dart
+++ b/test/util.test.dart
@@ -120,6 +120,7 @@ void main() {
             {
               'message': imageMessage,
               'nextMessageInGroup': false,
+              'isFirstInGroup': true,
               'showName': false,
               'showStatus': true,
             },
@@ -127,6 +128,7 @@ void main() {
             {
               'message': message,
               'nextMessageInGroup': false,
+              'isFirstInGroup': true,
               'showName': false,
               'showStatus': true,
             },
@@ -166,6 +168,7 @@ void main() {
               {
                 'message': imageMessage,
                 'nextMessageInGroup': false,
+                'isFirstInGroup': true,
                 'showName': false,
                 'showStatus': true,
               },
@@ -174,6 +177,7 @@ void main() {
               {
                 'message': message,
                 'nextMessageInGroup': false,
+                'isFirstInGroup': true,
                 'showName': false,
                 'showStatus': true,
               },
@@ -212,6 +216,7 @@ void main() {
               {
                 'message': imageMessage,
                 'nextMessageInGroup': false,
+                'isFirstInGroup': true,
                 'showName': false,
                 'showStatus': true,
               },
@@ -219,6 +224,7 @@ void main() {
               {
                 'message': message,
                 'nextMessageInGroup': false,
+                'isFirstInGroup': true,
                 'showName': false,
                 'showStatus': true,
               },
@@ -261,6 +267,7 @@ void main() {
                 {
                   'message': imageMessage,
                   'nextMessageInGroup': false,
+                  'isFirstInGroup': true,
                   'showName': false,
                   'showStatus': true,
                 },
@@ -269,6 +276,7 @@ void main() {
                 {
                   'message': message,
                   'nextMessageInGroup': false,
+                  'isFirstInGroup': true,
                   'showName': false,
                   'showStatus': true,
                 },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds a new parameter to bubble builder named `isFirstInGroup`.

### Why is it needed?

It helps us to determine first message in group or a single message. I need it because in my situation I need to show user names and avatars on first message. To do it I need to check for first message but current version of chat_ui doesn't allow to check it. 
<img width="303" alt="Screenshot 2024-10-08 at 07 27 19" src="https://github.com/user-attachments/assets/c8d3e1cf-eed3-4f8c-9991-a7ff9e153dc3">

### How to test it?

Change your flutter_chat_ui version on pubspec.yaml like that:
```
flutter_chat_ui:
    git:
      url: 'https://github.com/berkeenesakt/flutter_chat_ui.git'
      ref: 'feature-first-message-in-group'
```
Update your bubble builder like that
```
bubbleBuilder: (child, {required isFirstInGroup, required message, required nextMessageInGroup}) {
...
```
Now you can check for first message with `isFirstInGroup` parameter.

### Related issues/PRs

https://github.com/flyerhq/flutter_chat_ui/issues/182