### PR TITLE
fix Error: The non-abstract class 'CachedNetworkImage' is missing imp…

### DIFF
--- a/packages/cross_cache/lib/src/cached_network_image.dart
+++ b/packages/cross_cache/lib/src/cached_network_image.dart
@@ -31,6 +31,9 @@ class CachedNetworkImage extends ImageProvider<NetworkImage>
   final Map<String, String>? headers;
 
   @override
+  WebHtmlElementStrategy get webHtmlElementStrategy => WebHtmlElementStrategy.never;
+
+  @override
   Future<NetworkImage> obtainKey(ImageConfiguration configuration) {
     return SynchronousFuture<NetworkImage>(this);
   }


### PR DESCRIPTION
fix Error: The non-abstract class 'CachedNetworkImage' is missing implementations for these members: NetworkImage.webHtmlElementStrategy