### PR TITLE
Downgrade intl version

### DIFF
--- a/packages/flutter_chat_core/pubspec.yaml
+++ b/packages/flutter_chat_core/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^2.4.4
-  intl: ^0.20.2
+  intl: ^0.19.0
   json_annotation: ^4.9.0
   path_provider: ^2.1.5
 


### PR DESCRIPTION
As of right now the latest flutter version has `flutter_localizations` with [intl pinned](https://github.com/flutter/flutter/blob/c23637390482d4cf9598c3ce3f2be31aa7332daf/packages/flutter_localizations/pubspec.yaml#L14) at `0.19.0`. This meas that apps that use `flutter_localizations` are unable to import `flutter_chat_core`.