### PR TITLE
feat: various changes

### DIFF
--- a/examples/flyer_chat/lib/basic.dart
+++ b/examples/flyer_chat/lib/basic.dart
@@ -38,7 +38,7 @@ class BasicState extends State<Basic> {
           );
         },
         resolveUser: (UserID id) async {
-          return User(id: id, firstName: 'John', lastName: 'Doe');
+          return User(id: id, name: 'John Doe');
         },
       ),
     );

--- a/examples/flyer_chat/lib/create_message.dart
+++ b/examples/flyer_chat/lib/create_message.dart
@@ -9,6 +9,7 @@ Future<Message> createMessage(
   UserID authorId,
   Dio dio, {
   bool? textOnly,
+  bool? localOnly,
   String? text,
 }) async {
   const uuid = Uuid();
@@ -19,9 +20,9 @@ Future<Message> createMessage(
       id: uuid.v4(),
       authorId: authorId,
       createdAt: DateTime.now().toUtc(),
-      sentAt: DateTime.now().toUtc(),
+      sentAt: localOnly == true ? DateTime.now().toUtc() : null,
       text: text ?? lorem(paragraphs: 1, words: Random().nextInt(30) + 1),
-      isOnlyEmoji: isOnlyEmoji(text ?? ''),
+      metadata: isOnlyEmoji(text ?? '') ? {'isOnlyEmoji': true} : null,
     );
   } else {
     final orientation = ['portrait', 'square', 'wide'][Random().nextInt(3)];
@@ -53,7 +54,7 @@ Future<Message> createMessage(
       id: uuid.v4(),
       authorId: authorId,
       createdAt: DateTime.now().toUtc(),
-      sentAt: DateTime.now().toUtc(),
+      sentAt: localOnly == true ? DateTime.now().toUtc() : null,
       source: response.data['img'],
       thumbhash: response.data['thumbhash'],
       blurhash: response.data['blurhash'],
@@ -64,6 +65,7 @@ Future<Message> createMessage(
   //   id: uuid.v4(),
   //   author: author,
   //   createdAt: DateTime.now().toUtc(),
+  //   sentAt: localOnly == true ? DateTime.now().toUtc() : null,
   //   source:
   //       'https://www.hdcarwallpapers.com/walls/audi_r8_spyder_v10_performance_rwd_2021_4k_8k-HD.jpg',
   //   thumbhash: '2gcODIKwdmg9eId1l4qTb2v4xw',

--- a/examples/flyer_chat/lib/gemini.dart
+++ b/examples/flyer_chat/lib/gemini.dart
@@ -81,8 +81,12 @@ class GeminiState extends State<Gemini> {
             );
           },
           imageMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatImageMessage(message: message, index: index),
+              (context, message, index) => FlyerChatImageMessage(
+                message: message,
+                index: index,
+                showTime: false,
+                showStatus: false,
+              ),
           composerBuilder:
               (context) => Composer(
                 topWidget: ComposerActionBar(
@@ -100,8 +104,12 @@ class GeminiState extends State<Gemini> {
                 ),
               ),
           textMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatTextMessage(message: message, index: index),
+              (context, message, index) => FlyerChatTextMessage(
+                message: message,
+                index: index,
+                showTime: false,
+                showStatus: false,
+              ),
         ),
         chatController: _chatController,
         crossCache: _crossCache,
@@ -124,9 +132,8 @@ class GeminiState extends State<Gemini> {
       TextMessage(
         id: _uuid.v4(),
         authorId: _currentUser.id,
-        createdAt: DateTime.now().toUtc(),
         text: text,
-        isOnlyEmoji: isOnlyEmoji(text),
+        metadata: isOnlyEmoji(text) ? {'isOnlyEmoji': true} : null,
       ),
     );
 
@@ -147,7 +154,6 @@ class GeminiState extends State<Gemini> {
       ImageMessage(
         id: _uuid.v4(),
         authorId: _currentUser.id,
-        createdAt: DateTime.now().toUtc(),
         source: image.path,
       ),
     );
@@ -182,17 +188,12 @@ class GeminiState extends State<Gemini> {
             _currentGeminiResponse = TextMessage(
               id: _uuid.v4(),
               authorId: _agent.id,
-              createdAt: DateTime.now().toUtc(),
               text: accumulatedText,
-              isOnlyEmoji: isOnlyEmoji(accumulatedText),
             );
             await _chatController.insert(_currentGeminiResponse!);
           } else {
             final newUpdatedMessage = (_currentGeminiResponse as TextMessage)
-                .copyWith(
-                  text: accumulatedText,
-                  isOnlyEmoji: isOnlyEmoji(accumulatedText),
-                );
+                .copyWith(text: accumulatedText);
             await _chatController.update(
               _currentGeminiResponse!,
               newUpdatedMessage,
@@ -242,6 +243,16 @@ class GeminiState extends State<Gemini> {
             }
           }
         }
+      }
+
+      if (_currentGeminiResponse != null) {
+        await _chatController.update(
+          _currentGeminiResponse!,
+          _currentGeminiResponse!.copyWith(
+            metadata:
+                isOnlyEmoji(accumulatedText) ? {'isOnlyEmoji': true} : null,
+          ),
+        );
       }
 
       _currentGeminiResponse = null;

--- a/examples/flyer_chat/lib/local.dart
+++ b/examples/flyer_chat/lib/local.dart
@@ -262,7 +262,12 @@ class LocalState extends State<Local> {
   void _addItem(String? text) async {
     final randomUser = Random().nextInt(2) == 0 ? _currentUser : _recipient;
 
-    final message = await createMessage(randomUser.id, widget.dio, text: text);
+    final message = await createMessage(
+      randomUser.id,
+      widget.dio,
+      localOnly: true,
+      text: text,
+    );
 
     if (mounted) {
       if (_isTyping) {
@@ -278,7 +283,6 @@ class LocalState extends State<Local> {
           SystemMessage(
             id: _uuid.v4(),
             authorId: _systemUser.id,
-            createdAt: now,
             text: formattedDate,
           ),
         );
@@ -293,7 +297,6 @@ class LocalState extends State<Local> {
         CustomMessage(
           id: _uuid.v4(),
           authorId: _systemUser.id,
-          createdAt: DateTime.now().toUtc(),
           metadata: {'type': 'typing'},
         ),
       );

--- a/packages/flutter_chat_core/lib/src/models/message.dart
+++ b/packages/flutter_chat_core/lib/src/models/message.dart
@@ -13,9 +13,8 @@ sealed class Message with _$Message {
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -25,16 +24,14 @@ sealed class Message with _$Message {
     Map<String, dynamic>? metadata,
     required String text,
     LinkPreview? linkPreview,
-    bool? isOnlyEmoji,
   }) = TextMessage;
 
   const factory Message.image({
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -55,9 +52,8 @@ sealed class Message with _$Message {
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -75,9 +71,8 @@ sealed class Message with _$Message {
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -92,9 +87,8 @@ sealed class Message with _$Message {
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -108,9 +102,8 @@ sealed class Message with _$Message {
     required MessageID id,
     required UserID authorId,
     MessageID? replyToId,
-    @EpochDateTimeConverter() required DateTime createdAt,
+    @EpochDateTimeConverter() DateTime? createdAt,
     @EpochDateTimeConverter() DateTime? deletedAt,
-    bool? sending,
     @EpochDateTimeConverter() DateTime? failedAt,
     @EpochDateTimeConverter() DateTime? sentAt,
     @EpochDateTimeConverter() DateTime? deliveredAt,
@@ -126,12 +119,21 @@ sealed class Message with _$Message {
     // Message status is determined by the most recent state change in the message lifecycle.
     // The order of checks matters - we check from most recent to oldest state.
     // Note: createdAt, updatedAt, and deletedAt are message states rather than statuses.
-    if (sending == true) return MessageStatus.sending;
+    if (metadata?['sending'] == true) return MessageStatus.sending;
     if (failedAt != null) return MessageStatus.error;
     if (seenAt != null) return MessageStatus.seen;
     if (deliveredAt != null) return MessageStatus.delivered;
     if (sentAt != null) return MessageStatus.sent;
     return null;
+  }
+
+  /// Returns the time displayed for the user when the message is shown in a list.
+  /// This time is determined by the `sentAt` date, which represents when the message was sent to the server.
+  /// If `sentAt` is not available, it falls back to the `createdAt` date.
+  /// Other timestamps like `updatedAt` may be shown in an additional history popup,
+  /// but they are not displayed in the list itself (this functionality is not provided by the package and is left to the user to implement).
+  DateTime? get time {
+    return sentAt ?? createdAt;
   }
 
   factory Message.fromJson(Map<String, dynamic> json) =>

--- a/packages/flutter_chat_core/lib/src/models/message.freezed.dart
+++ b/packages/flutter_chat_core/lib/src/models/message.freezed.dart
@@ -48,7 +48,7 @@ Message _$MessageFromJson(
 /// @nodoc
 mixin _$Message {
 
- MessageID get id; UserID get authorId; MessageID? get replyToId;@EpochDateTimeConverter() DateTime get createdAt;@EpochDateTimeConverter() DateTime? get deletedAt; bool? get sending;@EpochDateTimeConverter() DateTime? get failedAt;@EpochDateTimeConverter() DateTime? get sentAt;@EpochDateTimeConverter() DateTime? get deliveredAt;@EpochDateTimeConverter() DateTime? get seenAt;@EpochDateTimeConverter() DateTime? get updatedAt; Map<String, List<UserID>>? get reactions; Map<String, dynamic>? get metadata;
+ MessageID get id; UserID get authorId; MessageID? get replyToId;@EpochDateTimeConverter() DateTime? get createdAt;@EpochDateTimeConverter() DateTime? get deletedAt;@EpochDateTimeConverter() DateTime? get failedAt;@EpochDateTimeConverter() DateTime? get sentAt;@EpochDateTimeConverter() DateTime? get deliveredAt;@EpochDateTimeConverter() DateTime? get seenAt;@EpochDateTimeConverter() DateTime? get updatedAt; Map<String, List<UserID>>? get reactions; Map<String, dynamic>? get metadata;
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -61,16 +61,16 @@ $MessageCopyWith<Message> get copyWith => _$MessageCopyWithImpl<Message>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Message&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other.reactions, reactions)&&const DeepCollectionEquality().equals(other.metadata, metadata));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Message&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other.reactions, reactions)&&const DeepCollectionEquality().equals(other.metadata, metadata));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(reactions),const DeepCollectionEquality().hash(metadata));
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(reactions),const DeepCollectionEquality().hash(metadata));
 
 @override
 String toString() {
-  return 'Message(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
+  return 'Message(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
 }
 
 
@@ -81,7 +81,7 @@ abstract mixin class $MessageCopyWith<$Res>  {
   factory $MessageCopyWith(Message value, $Res Function(Message) _then) = _$MessageCopyWithImpl;
 @useResult
 $Res call({
- String id, String authorId, String? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<String>>? reactions, Map<String, dynamic>? metadata
+ String id, String authorId, String? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<String>>? reactions, Map<String, dynamic>? metadata
 });
 
 
@@ -98,15 +98,14 @@ class _$MessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as String,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -124,15 +123,14 @@ as Map<String, dynamic>?,
 @JsonSerializable()
 
 class TextMessage extends Message {
-  const TextMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.text, this.linkPreview, this.isOnlyEmoji, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'text',super._();
+  const TextMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.text, this.linkPreview, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'text',super._();
   factory TextMessage.fromJson(Map<String, dynamic> json) => _$TextMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -158,7 +156,6 @@ class TextMessage extends Message {
 
  final  String text;
  final  LinkPreview? linkPreview;
- final  bool? isOnlyEmoji;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -177,16 +174,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TextMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.text, text) || other.text == text)&&(identical(other.linkPreview, linkPreview) || other.linkPreview == linkPreview)&&(identical(other.isOnlyEmoji, isOnlyEmoji) || other.isOnlyEmoji == isOnlyEmoji));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TextMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.text, text) || other.text == text)&&(identical(other.linkPreview, linkPreview) || other.linkPreview == linkPreview));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),text,linkPreview,isOnlyEmoji);
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),text,linkPreview);
 
 @override
 String toString() {
-  return 'Message.text(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, text: $text, linkPreview: $linkPreview, isOnlyEmoji: $isOnlyEmoji)';
+  return 'Message.text(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, text: $text, linkPreview: $linkPreview)';
 }
 
 
@@ -197,7 +194,7 @@ abstract mixin class $TextMessageCopyWith<$Res> implements $MessageCopyWith<$Res
   factory $TextMessageCopyWith(TextMessage value, $Res Function(TextMessage) _then) = _$TextMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String text, LinkPreview? linkPreview, bool? isOnlyEmoji
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String text, LinkPreview? linkPreview
 });
 
 
@@ -214,15 +211,14 @@ class _$TextMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? text = null,Object? linkPreview = freezed,Object? isOnlyEmoji = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? text = null,Object? linkPreview = freezed,}) {
   return _then(TextMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -231,8 +227,7 @@ as DateTime?,reactions: freezed == reactions ? _self._reactions : reactions // i
 as Map<String, List<UserID>>?,metadata: freezed == metadata ? _self._metadata : metadata // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,linkPreview: freezed == linkPreview ? _self.linkPreview : linkPreview // ignore: cast_nullable_to_non_nullable
-as LinkPreview?,isOnlyEmoji: freezed == isOnlyEmoji ? _self.isOnlyEmoji : isOnlyEmoji // ignore: cast_nullable_to_non_nullable
-as bool?,
+as LinkPreview?,
   ));
 }
 
@@ -255,15 +250,14 @@ $LinkPreviewCopyWith<$Res>? get linkPreview {
 @JsonSerializable()
 
 class ImageMessage extends Message {
-  const ImageMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.source, this.text, this.thumbhash, this.blurhash, this.width, this.height, this.hasOverlay, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'image',super._();
+  const ImageMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.source, this.text, this.thumbhash, this.blurhash, this.width, this.height, this.hasOverlay, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'image',super._();
   factory ImageMessage.fromJson(Map<String, dynamic> json) => _$ImageMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -312,16 +306,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ImageMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.source, source) || other.source == source)&&(identical(other.text, text) || other.text == text)&&(identical(other.thumbhash, thumbhash) || other.thumbhash == thumbhash)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.hasOverlay, hasOverlay) || other.hasOverlay == hasOverlay));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ImageMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.source, source) || other.source == source)&&(identical(other.text, text) || other.text == text)&&(identical(other.thumbhash, thumbhash) || other.thumbhash == thumbhash)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.hasOverlay, hasOverlay) || other.hasOverlay == hasOverlay));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),source,text,thumbhash,blurhash,width,height,hasOverlay]);
+int get hashCode => Object.hashAll([runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),source,text,thumbhash,blurhash,width,height,hasOverlay]);
 
 @override
 String toString() {
-  return 'Message.image(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, source: $source, text: $text, thumbhash: $thumbhash, blurhash: $blurhash, width: $width, height: $height, hasOverlay: $hasOverlay)';
+  return 'Message.image(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, source: $source, text: $text, thumbhash: $thumbhash, blurhash: $blurhash, width: $width, height: $height, hasOverlay: $hasOverlay)';
 }
 
 
@@ -332,7 +326,7 @@ abstract mixin class $ImageMessageCopyWith<$Res> implements $MessageCopyWith<$Re
   factory $ImageMessageCopyWith(ImageMessage value, $Res Function(ImageMessage) _then) = _$ImageMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String source, String? text, String? thumbhash, String? blurhash, double? width, double? height, bool? hasOverlay
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String source, String? text, String? thumbhash, String? blurhash, double? width, double? height, bool? hasOverlay
 });
 
 
@@ -349,15 +343,14 @@ class _$ImageMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? source = null,Object? text = freezed,Object? thumbhash = freezed,Object? blurhash = freezed,Object? width = freezed,Object? height = freezed,Object? hasOverlay = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? source = null,Object? text = freezed,Object? thumbhash = freezed,Object? blurhash = freezed,Object? width = freezed,Object? height = freezed,Object? hasOverlay = freezed,}) {
   return _then(ImageMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -382,15 +375,14 @@ as bool?,
 @JsonSerializable()
 
 class FileMessage extends Message {
-  const FileMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.source, required this.name, this.size, this.mimeType, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'file',super._();
+  const FileMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.source, required this.name, this.size, this.mimeType, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'file',super._();
   factory FileMessage.fromJson(Map<String, dynamic> json) => _$FileMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -436,16 +428,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FileMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.source, source) || other.source == source)&&(identical(other.name, name) || other.name == name)&&(identical(other.size, size) || other.size == size)&&(identical(other.mimeType, mimeType) || other.mimeType == mimeType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FileMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.source, source) || other.source == source)&&(identical(other.name, name) || other.name == name)&&(identical(other.size, size) || other.size == size)&&(identical(other.mimeType, mimeType) || other.mimeType == mimeType));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),source,name,size,mimeType);
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),source,name,size,mimeType);
 
 @override
 String toString() {
-  return 'Message.file(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, source: $source, name: $name, size: $size, mimeType: $mimeType)';
+  return 'Message.file(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, source: $source, name: $name, size: $size, mimeType: $mimeType)';
 }
 
 
@@ -456,7 +448,7 @@ abstract mixin class $FileMessageCopyWith<$Res> implements $MessageCopyWith<$Res
   factory $FileMessageCopyWith(FileMessage value, $Res Function(FileMessage) _then) = _$FileMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String source, String name, int? size, String? mimeType
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String source, String name, int? size, String? mimeType
 });
 
 
@@ -473,15 +465,14 @@ class _$FileMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? source = null,Object? name = null,Object? size = freezed,Object? mimeType = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? source = null,Object? name = null,Object? size = freezed,Object? mimeType = freezed,}) {
   return _then(FileMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -503,15 +494,14 @@ as String?,
 @JsonSerializable()
 
 class SystemMessage extends Message {
-  const SystemMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.text, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'system',super._();
+  const SystemMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, required this.text, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'system',super._();
   factory SystemMessage.fromJson(Map<String, dynamic> json) => _$SystemMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -554,16 +544,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.text, text) || other.text == text));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SystemMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.text, text) || other.text == text));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),text);
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata),text);
 
 @override
 String toString() {
-  return 'Message.system(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, text: $text)';
+  return 'Message.system(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata, text: $text)';
 }
 
 
@@ -574,7 +564,7 @@ abstract mixin class $SystemMessageCopyWith<$Res> implements $MessageCopyWith<$R
   factory $SystemMessageCopyWith(SystemMessage value, $Res Function(SystemMessage) _then) = _$SystemMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String text
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata, String text
 });
 
 
@@ -591,15 +581,14 @@ class _$SystemMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? text = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,Object? text = null,}) {
   return _then(SystemMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -618,15 +607,14 @@ as String,
 @JsonSerializable()
 
 class CustomMessage extends Message {
-  const CustomMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'custom',super._();
+  const CustomMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'custom',super._();
   factory CustomMessage.fromJson(Map<String, dynamic> json) => _$CustomMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -668,16 +656,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CustomMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CustomMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata));
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata));
 
 @override
 String toString() {
-  return 'Message.custom(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
+  return 'Message.custom(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
 }
 
 
@@ -688,7 +676,7 @@ abstract mixin class $CustomMessageCopyWith<$Res> implements $MessageCopyWith<$R
   factory $CustomMessageCopyWith(CustomMessage value, $Res Function(CustomMessage) _then) = _$CustomMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata
 });
 
 
@@ -705,15 +693,14 @@ class _$CustomMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
   return _then(CustomMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable
@@ -731,15 +718,14 @@ as Map<String, dynamic>?,
 @JsonSerializable()
 
 class UnsupportedMessage extends Message {
-  const UnsupportedMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() required this.createdAt, @EpochDateTimeConverter() this.deletedAt, this.sending, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'unsupported',super._();
+  const UnsupportedMessage({required this.id, required this.authorId, this.replyToId, @EpochDateTimeConverter() this.createdAt, @EpochDateTimeConverter() this.deletedAt, @EpochDateTimeConverter() this.failedAt, @EpochDateTimeConverter() this.sentAt, @EpochDateTimeConverter() this.deliveredAt, @EpochDateTimeConverter() this.seenAt, @EpochDateTimeConverter() this.updatedAt, final  Map<String, List<UserID>>? reactions, final  Map<String, dynamic>? metadata, final  String? $type}): _reactions = reactions,_metadata = metadata,$type = $type ?? 'unsupported',super._();
   factory UnsupportedMessage.fromJson(Map<String, dynamic> json) => _$UnsupportedMessageFromJson(json);
 
 @override final  MessageID id;
 @override final  UserID authorId;
 @override final  MessageID? replyToId;
-@override@EpochDateTimeConverter() final  DateTime createdAt;
+@override@EpochDateTimeConverter() final  DateTime? createdAt;
 @override@EpochDateTimeConverter() final  DateTime? deletedAt;
-@override final  bool? sending;
 @override@EpochDateTimeConverter() final  DateTime? failedAt;
 @override@EpochDateTimeConverter() final  DateTime? sentAt;
 @override@EpochDateTimeConverter() final  DateTime? deliveredAt;
@@ -781,16 +767,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UnsupportedMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.sending, sending) || other.sending == sending)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UnsupportedMessage&&(identical(other.id, id) || other.id == id)&&(identical(other.authorId, authorId) || other.authorId == authorId)&&(identical(other.replyToId, replyToId) || other.replyToId == replyToId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.failedAt, failedAt) || other.failedAt == failedAt)&&(identical(other.sentAt, sentAt) || other.sentAt == sentAt)&&(identical(other.deliveredAt, deliveredAt) || other.deliveredAt == deliveredAt)&&(identical(other.seenAt, seenAt) || other.seenAt == seenAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other._reactions, _reactions)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,sending,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata));
+int get hashCode => Object.hash(runtimeType,id,authorId,replyToId,createdAt,deletedAt,failedAt,sentAt,deliveredAt,seenAt,updatedAt,const DeepCollectionEquality().hash(_reactions),const DeepCollectionEquality().hash(_metadata));
 
 @override
 String toString() {
-  return 'Message.unsupported(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, sending: $sending, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
+  return 'Message.unsupported(id: $id, authorId: $authorId, replyToId: $replyToId, createdAt: $createdAt, deletedAt: $deletedAt, failedAt: $failedAt, sentAt: $sentAt, deliveredAt: $deliveredAt, seenAt: $seenAt, updatedAt: $updatedAt, reactions: $reactions, metadata: $metadata)';
 }
 
 
@@ -801,7 +787,7 @@ abstract mixin class $UnsupportedMessageCopyWith<$Res> implements $MessageCopyWi
   factory $UnsupportedMessageCopyWith(UnsupportedMessage value, $Res Function(UnsupportedMessage) _then) = _$UnsupportedMessageCopyWithImpl;
 @override @useResult
 $Res call({
- MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime createdAt,@EpochDateTimeConverter() DateTime? deletedAt, bool? sending,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata
+ MessageID id, UserID authorId, MessageID? replyToId,@EpochDateTimeConverter() DateTime? createdAt,@EpochDateTimeConverter() DateTime? deletedAt,@EpochDateTimeConverter() DateTime? failedAt,@EpochDateTimeConverter() DateTime? sentAt,@EpochDateTimeConverter() DateTime? deliveredAt,@EpochDateTimeConverter() DateTime? seenAt,@EpochDateTimeConverter() DateTime? updatedAt, Map<String, List<UserID>>? reactions, Map<String, dynamic>? metadata
 });
 
 
@@ -818,15 +804,14 @@ class _$UnsupportedMessageCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = null,Object? deletedAt = freezed,Object? sending = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? authorId = null,Object? replyToId = freezed,Object? createdAt = freezed,Object? deletedAt = freezed,Object? failedAt = freezed,Object? sentAt = freezed,Object? deliveredAt = freezed,Object? seenAt = freezed,Object? updatedAt = freezed,Object? reactions = freezed,Object? metadata = freezed,}) {
   return _then(UnsupportedMessage(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MessageID,authorId: null == authorId ? _self.authorId : authorId // ignore: cast_nullable_to_non_nullable
 as UserID,replyToId: freezed == replyToId ? _self.replyToId : replyToId // ignore: cast_nullable_to_non_nullable
-as MessageID?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,sending: freezed == sending ? _self.sending : sending // ignore: cast_nullable_to_non_nullable
-as bool?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
+as MessageID?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,failedAt: freezed == failedAt ? _self.failedAt : failedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,sentAt: freezed == sentAt ? _self.sentAt : sentAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deliveredAt: freezed == deliveredAt ? _self.deliveredAt : deliveredAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,seenAt: freezed == seenAt ? _self.seenAt : seenAt // ignore: cast_nullable_to_non_nullable

--- a/packages/flutter_chat_core/lib/src/models/message.g.dart
+++ b/packages/flutter_chat_core/lib/src/models/message.g.dart
@@ -10,14 +10,14 @@ TextMessage _$TextMessageFromJson(Map<String, dynamic> json) => TextMessage(
   id: json['id'] as String,
   authorId: json['authorId'] as String,
   replyToId: json['replyToId'] as String?,
-  createdAt: const EpochDateTimeConverter().fromJson(
-    (json['createdAt'] as num).toInt(),
+  createdAt: _$JsonConverterFromJson<int, DateTime>(
+    json['createdAt'],
+    const EpochDateTimeConverter().fromJson,
   ),
   deletedAt: _$JsonConverterFromJson<int, DateTime>(
     json['deletedAt'],
     const EpochDateTimeConverter().fromJson,
   ),
-  sending: json['sending'] as bool?,
   failedAt: _$JsonConverterFromJson<int, DateTime>(
     json['failedAt'],
     const EpochDateTimeConverter().fromJson,
@@ -48,7 +48,6 @@ TextMessage _$TextMessageFromJson(Map<String, dynamic> json) => TextMessage(
       json['linkPreview'] == null
           ? null
           : LinkPreview.fromJson(json['linkPreview'] as Map<String, dynamic>),
-  isOnlyEmoji: json['isOnlyEmoji'] as bool?,
   $type: json['type'] as String?,
 );
 
@@ -58,14 +57,18 @@ Map<String, dynamic> _$TextMessageToJson(
   'id': instance.id,
   'authorId': instance.authorId,
   if (instance.replyToId case final value?) 'replyToId': value,
-  'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+  if (_$JsonConverterToJson<int, DateTime>(
+        instance.createdAt,
+        const EpochDateTimeConverter().toJson,
+      )
+      case final value?)
+    'createdAt': value,
   if (_$JsonConverterToJson<int, DateTime>(
         instance.deletedAt,
         const EpochDateTimeConverter().toJson,
       )
       case final value?)
     'deletedAt': value,
-  if (instance.sending case final value?) 'sending': value,
   if (_$JsonConverterToJson<int, DateTime>(
         instance.failedAt,
         const EpochDateTimeConverter().toJson,
@@ -100,7 +103,6 @@ Map<String, dynamic> _$TextMessageToJson(
   if (instance.metadata case final value?) 'metadata': value,
   'text': instance.text,
   if (instance.linkPreview?.toJson() case final value?) 'linkPreview': value,
-  if (instance.isOnlyEmoji case final value?) 'isOnlyEmoji': value,
   'type': instance.$type,
 };
 
@@ -118,14 +120,14 @@ ImageMessage _$ImageMessageFromJson(Map<String, dynamic> json) => ImageMessage(
   id: json['id'] as String,
   authorId: json['authorId'] as String,
   replyToId: json['replyToId'] as String?,
-  createdAt: const EpochDateTimeConverter().fromJson(
-    (json['createdAt'] as num).toInt(),
+  createdAt: _$JsonConverterFromJson<int, DateTime>(
+    json['createdAt'],
+    const EpochDateTimeConverter().fromJson,
   ),
   deletedAt: _$JsonConverterFromJson<int, DateTime>(
     json['deletedAt'],
     const EpochDateTimeConverter().fromJson,
   ),
-  sending: json['sending'] as bool?,
   failedAt: _$JsonConverterFromJson<int, DateTime>(
     json['failedAt'],
     const EpochDateTimeConverter().fromJson,
@@ -166,14 +168,18 @@ Map<String, dynamic> _$ImageMessageToJson(ImageMessage instance) =>
       'id': instance.id,
       'authorId': instance.authorId,
       if (instance.replyToId case final value?) 'replyToId': value,
-      'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+      if (_$JsonConverterToJson<int, DateTime>(
+            instance.createdAt,
+            const EpochDateTimeConverter().toJson,
+          )
+          case final value?)
+        'createdAt': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.deletedAt,
             const EpochDateTimeConverter().toJson,
           )
           case final value?)
         'deletedAt': value,
-      if (instance.sending case final value?) 'sending': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.failedAt,
             const EpochDateTimeConverter().toJson,
@@ -220,14 +226,14 @@ FileMessage _$FileMessageFromJson(Map<String, dynamic> json) => FileMessage(
   id: json['id'] as String,
   authorId: json['authorId'] as String,
   replyToId: json['replyToId'] as String?,
-  createdAt: const EpochDateTimeConverter().fromJson(
-    (json['createdAt'] as num).toInt(),
+  createdAt: _$JsonConverterFromJson<int, DateTime>(
+    json['createdAt'],
+    const EpochDateTimeConverter().fromJson,
   ),
   deletedAt: _$JsonConverterFromJson<int, DateTime>(
     json['deletedAt'],
     const EpochDateTimeConverter().fromJson,
   ),
-  sending: json['sending'] as bool?,
   failedAt: _$JsonConverterFromJson<int, DateTime>(
     json['failedAt'],
     const EpochDateTimeConverter().fromJson,
@@ -265,14 +271,18 @@ Map<String, dynamic> _$FileMessageToJson(FileMessage instance) =>
       'id': instance.id,
       'authorId': instance.authorId,
       if (instance.replyToId case final value?) 'replyToId': value,
-      'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+      if (_$JsonConverterToJson<int, DateTime>(
+            instance.createdAt,
+            const EpochDateTimeConverter().toJson,
+          )
+          case final value?)
+        'createdAt': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.deletedAt,
             const EpochDateTimeConverter().toJson,
           )
           case final value?)
         'deletedAt': value,
-      if (instance.sending case final value?) 'sending': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.failedAt,
             const EpochDateTimeConverter().toJson,
@@ -317,14 +327,14 @@ SystemMessage _$SystemMessageFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       authorId: json['authorId'] as String,
       replyToId: json['replyToId'] as String?,
-      createdAt: const EpochDateTimeConverter().fromJson(
-        (json['createdAt'] as num).toInt(),
+      createdAt: _$JsonConverterFromJson<int, DateTime>(
+        json['createdAt'],
+        const EpochDateTimeConverter().fromJson,
       ),
       deletedAt: _$JsonConverterFromJson<int, DateTime>(
         json['deletedAt'],
         const EpochDateTimeConverter().fromJson,
       ),
-      sending: json['sending'] as bool?,
       failedAt: _$JsonConverterFromJson<int, DateTime>(
         json['failedAt'],
         const EpochDateTimeConverter().fromJson,
@@ -359,14 +369,18 @@ Map<String, dynamic> _$SystemMessageToJson(SystemMessage instance) =>
       'id': instance.id,
       'authorId': instance.authorId,
       if (instance.replyToId case final value?) 'replyToId': value,
-      'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+      if (_$JsonConverterToJson<int, DateTime>(
+            instance.createdAt,
+            const EpochDateTimeConverter().toJson,
+          )
+          case final value?)
+        'createdAt': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.deletedAt,
             const EpochDateTimeConverter().toJson,
           )
           case final value?)
         'deletedAt': value,
-      if (instance.sending case final value?) 'sending': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.failedAt,
             const EpochDateTimeConverter().toJson,
@@ -408,14 +422,14 @@ CustomMessage _$CustomMessageFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       authorId: json['authorId'] as String,
       replyToId: json['replyToId'] as String?,
-      createdAt: const EpochDateTimeConverter().fromJson(
-        (json['createdAt'] as num).toInt(),
+      createdAt: _$JsonConverterFromJson<int, DateTime>(
+        json['createdAt'],
+        const EpochDateTimeConverter().fromJson,
       ),
       deletedAt: _$JsonConverterFromJson<int, DateTime>(
         json['deletedAt'],
         const EpochDateTimeConverter().fromJson,
       ),
-      sending: json['sending'] as bool?,
       failedAt: _$JsonConverterFromJson<int, DateTime>(
         json['failedAt'],
         const EpochDateTimeConverter().fromJson,
@@ -449,14 +463,18 @@ Map<String, dynamic> _$CustomMessageToJson(CustomMessage instance) =>
       'id': instance.id,
       'authorId': instance.authorId,
       if (instance.replyToId case final value?) 'replyToId': value,
-      'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+      if (_$JsonConverterToJson<int, DateTime>(
+            instance.createdAt,
+            const EpochDateTimeConverter().toJson,
+          )
+          case final value?)
+        'createdAt': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.deletedAt,
             const EpochDateTimeConverter().toJson,
           )
           case final value?)
         'deletedAt': value,
-      if (instance.sending case final value?) 'sending': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.failedAt,
             const EpochDateTimeConverter().toJson,
@@ -497,14 +515,14 @@ UnsupportedMessage _$UnsupportedMessageFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       authorId: json['authorId'] as String,
       replyToId: json['replyToId'] as String?,
-      createdAt: const EpochDateTimeConverter().fromJson(
-        (json['createdAt'] as num).toInt(),
+      createdAt: _$JsonConverterFromJson<int, DateTime>(
+        json['createdAt'],
+        const EpochDateTimeConverter().fromJson,
       ),
       deletedAt: _$JsonConverterFromJson<int, DateTime>(
         json['deletedAt'],
         const EpochDateTimeConverter().fromJson,
       ),
-      sending: json['sending'] as bool?,
       failedAt: _$JsonConverterFromJson<int, DateTime>(
         json['failedAt'],
         const EpochDateTimeConverter().fromJson,
@@ -538,14 +556,18 @@ Map<String, dynamic> _$UnsupportedMessageToJson(UnsupportedMessage instance) =>
       'id': instance.id,
       'authorId': instance.authorId,
       if (instance.replyToId case final value?) 'replyToId': value,
-      'createdAt': const EpochDateTimeConverter().toJson(instance.createdAt),
+      if (_$JsonConverterToJson<int, DateTime>(
+            instance.createdAt,
+            const EpochDateTimeConverter().toJson,
+          )
+          case final value?)
+        'createdAt': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.deletedAt,
             const EpochDateTimeConverter().toJson,
           )
           case final value?)
         'deletedAt': value,
-      if (instance.sending case final value?) 'sending': value,
       if (_$JsonConverterToJson<int, DateTime>(
             instance.failedAt,
             const EpochDateTimeConverter().toJson,

--- a/packages/flutter_chat_core/lib/src/models/user.dart
+++ b/packages/flutter_chat_core/lib/src/models/user.dart
@@ -10,8 +10,7 @@ part 'user.g.dart';
 abstract class User with _$User {
   const factory User({
     required UserID id,
-    String? firstName,
-    String? lastName,
+    String? name,
     String? imageSource,
     @EpochDateTimeConverter() DateTime? createdAt,
     Map<String, dynamic>? metadata,

--- a/packages/flutter_chat_core/lib/src/models/user.freezed.dart
+++ b/packages/flutter_chat_core/lib/src/models/user.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$User {
 
- UserID get id; String? get firstName; String? get lastName; String? get imageSource;@EpochDateTimeConverter() DateTime? get createdAt; Map<String, dynamic>? get metadata;
+ UserID get id; String? get name; String? get imageSource;@EpochDateTimeConverter() DateTime? get createdAt; Map<String, dynamic>? get metadata;
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $UserCopyWith<User> get copyWith => _$UserCopyWithImpl<User>(this as User, _$ide
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.id, id) || other.id == id)&&(identical(other.firstName, firstName) || other.firstName == firstName)&&(identical(other.lastName, lastName) || other.lastName == lastName)&&(identical(other.imageSource, imageSource) || other.imageSource == imageSource)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.metadata, metadata));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.imageSource, imageSource) || other.imageSource == imageSource)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.metadata, metadata));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,firstName,lastName,imageSource,createdAt,const DeepCollectionEquality().hash(metadata));
+int get hashCode => Object.hash(runtimeType,id,name,imageSource,createdAt,const DeepCollectionEquality().hash(metadata));
 
 @override
 String toString() {
-  return 'User(id: $id, firstName: $firstName, lastName: $lastName, imageSource: $imageSource, createdAt: $createdAt, metadata: $metadata)';
+  return 'User(id: $id, name: $name, imageSource: $imageSource, createdAt: $createdAt, metadata: $metadata)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $UserCopyWith<$Res>  {
   factory $UserCopyWith(User value, $Res Function(User) _then) = _$UserCopyWithImpl;
 @useResult
 $Res call({
- UserID id, String? firstName, String? lastName, String? imageSource,@EpochDateTimeConverter() DateTime? createdAt, Map<String, dynamic>? metadata
+ UserID id, String? name, String? imageSource,@EpochDateTimeConverter() DateTime? createdAt, Map<String, dynamic>? metadata
 });
 
 
@@ -66,11 +66,10 @@ class _$UserCopyWithImpl<$Res>
 
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? firstName = freezed,Object? lastName = freezed,Object? imageSource = freezed,Object? createdAt = freezed,Object? metadata = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? imageSource = freezed,Object? createdAt = freezed,Object? metadata = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as UserID,firstName: freezed == firstName ? _self.firstName : firstName // ignore: cast_nullable_to_non_nullable
-as String?,lastName: freezed == lastName ? _self.lastName : lastName // ignore: cast_nullable_to_non_nullable
+as UserID,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,imageSource: freezed == imageSource ? _self.imageSource : imageSource // ignore: cast_nullable_to_non_nullable
 as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
@@ -85,12 +84,11 @@ as Map<String, dynamic>?,
 @JsonSerializable()
 
 class _User extends User {
-  const _User({required this.id, this.firstName, this.lastName, this.imageSource, @EpochDateTimeConverter() this.createdAt, final  Map<String, dynamic>? metadata}): _metadata = metadata,super._();
+  const _User({required this.id, this.name, this.imageSource, @EpochDateTimeConverter() this.createdAt, final  Map<String, dynamic>? metadata}): _metadata = metadata,super._();
   factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
 @override final  UserID id;
-@override final  String? firstName;
-@override final  String? lastName;
+@override final  String? name;
 @override final  String? imageSource;
 @override@EpochDateTimeConverter() final  DateTime? createdAt;
  final  Map<String, dynamic>? _metadata;
@@ -116,16 +114,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.id, id) || other.id == id)&&(identical(other.firstName, firstName) || other.firstName == firstName)&&(identical(other.lastName, lastName) || other.lastName == lastName)&&(identical(other.imageSource, imageSource) || other.imageSource == imageSource)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.imageSource, imageSource) || other.imageSource == imageSource)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,firstName,lastName,imageSource,createdAt,const DeepCollectionEquality().hash(_metadata));
+int get hashCode => Object.hash(runtimeType,id,name,imageSource,createdAt,const DeepCollectionEquality().hash(_metadata));
 
 @override
 String toString() {
-  return 'User(id: $id, firstName: $firstName, lastName: $lastName, imageSource: $imageSource, createdAt: $createdAt, metadata: $metadata)';
+  return 'User(id: $id, name: $name, imageSource: $imageSource, createdAt: $createdAt, metadata: $metadata)';
 }
 
 
@@ -136,7 +134,7 @@ abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
   factory _$UserCopyWith(_User value, $Res Function(_User) _then) = __$UserCopyWithImpl;
 @override @useResult
 $Res call({
- UserID id, String? firstName, String? lastName, String? imageSource,@EpochDateTimeConverter() DateTime? createdAt, Map<String, dynamic>? metadata
+ UserID id, String? name, String? imageSource,@EpochDateTimeConverter() DateTime? createdAt, Map<String, dynamic>? metadata
 });
 
 
@@ -153,11 +151,10 @@ class __$UserCopyWithImpl<$Res>
 
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? firstName = freezed,Object? lastName = freezed,Object? imageSource = freezed,Object? createdAt = freezed,Object? metadata = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? imageSource = freezed,Object? createdAt = freezed,Object? metadata = freezed,}) {
   return _then(_User(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as UserID,firstName: freezed == firstName ? _self.firstName : firstName // ignore: cast_nullable_to_non_nullable
-as String?,lastName: freezed == lastName ? _self.lastName : lastName // ignore: cast_nullable_to_non_nullable
+as UserID,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,imageSource: freezed == imageSource ? _self.imageSource : imageSource // ignore: cast_nullable_to_non_nullable
 as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,metadata: freezed == metadata ? _self._metadata : metadata // ignore: cast_nullable_to_non_nullable

--- a/packages/flutter_chat_core/lib/src/models/user.g.dart
+++ b/packages/flutter_chat_core/lib/src/models/user.g.dart
@@ -8,8 +8,7 @@ part of 'user.dart';
 
 _User _$UserFromJson(Map<String, dynamic> json) => _User(
   id: json['id'] as String,
-  firstName: json['firstName'] as String?,
-  lastName: json['lastName'] as String?,
+  name: json['name'] as String?,
   imageSource: json['imageSource'] as String?,
   createdAt: _$JsonConverterFromJson<int, DateTime>(
     json['createdAt'],
@@ -20,8 +19,7 @@ _User _$UserFromJson(Map<String, dynamic> json) => _User(
 
 Map<String, dynamic> _$UserToJson(_User instance) => <String, dynamic>{
   'id': instance.id,
-  if (instance.firstName case final value?) 'firstName': value,
-  if (instance.lastName case final value?) 'lastName': value,
+  if (instance.name case final value?) 'name': value,
   if (instance.imageSource case final value?) 'imageSource': value,
   if (_$JsonConverterToJson<int, DateTime>(
         instance.createdAt,

--- a/packages/flutter_chat_core/test/chat_controller/in_memory_chat_controller_test.dart
+++ b/packages/flutter_chat_core/test/chat_controller/in_memory_chat_controller_test.dart
@@ -15,10 +15,6 @@ void main() {
     //   final newMessage = TextMessage(
     //     id: '21',
     //     authorId: 'me',
-    //     createdAt: DateTime.fromMillisecondsSinceEpoch(
-    //       1736893310000,
-    //       isUtc: true,
-    //     ),
     //     text: 'test',
     //   );
 
@@ -39,20 +35,12 @@ void main() {
     //   final newMessage1 = TextMessage(
     //     id: '21',
     //     authorId: 'me',
-    //     createdAt: DateTime.fromMillisecondsSinceEpoch(
-    //       1736893310000,
-    //       isUtc: true,
-    //     ),
     //     text: 'test',
     //   );
 
     //   final newMessage2 = TextMessage(
     //     id: '22',
     //     authorId: 'me',
-    //     createdAt: DateTime.fromMillisecondsSinceEpoch(
-    //       1736893310000,
-    //       isUtc: true,
-    //     ),
     //     text: 'test',
     //   );
 
@@ -66,10 +54,6 @@ void main() {
     //   final message = TextMessage(
     //     id: '21',
     //     authorId: 'me',
-    //     createdAt: DateTime.fromMillisecondsSinceEpoch(
-    //       1736893310000,
-    //       isUtc: true,
-    //     ),
     //     text: 'test',
     //   );
 

--- a/packages/flutter_chat_core/test/models/message_test.dart
+++ b/packages/flutter_chat_core/test/models/message_test.dart
@@ -365,6 +365,24 @@ void main() {
       // Should not be equal
       expect(message == messageDifferentTimestamp, false);
     });
+    test(
+      'copyWith overwrites metadata completely and does not expect any previous values',
+      () {
+        final copiedMessage = message.copyWith(
+          metadata: {'newKey': 'newValue'},
+        );
+
+        // Assert metadata contains only the new value (replacement)
+        expect(copiedMessage.metadata, {'newKey': 'newValue'});
+      },
+    );
+
+    test('copyWith with null metadata removes existing metadata', () {
+      final copiedMessage = message.copyWith(metadata: null);
+
+      // Assert metadata is null
+      expect(copiedMessage.metadata, null);
+    });
   });
 
   group('UnsupportedMessage', () {

--- a/packages/flutter_chat_ui/lib/src/avatar.dart
+++ b/packages/flutter_chat_ui/lib/src/avatar.dart
@@ -152,12 +152,11 @@ class _AvatarContentState extends State<AvatarContent> {
   }
 
   String _getInitials(User? user) {
-    if (user?.firstName == null && user?.lastName == null) return '';
+    if (user?.name == null || user!.name!.trim().isEmpty) return '';
 
-    final firstInitial =
-        user?.firstName?.isNotEmpty == true ? user!.firstName![0] : '';
-    final lastInitial =
-        user?.lastName?.isNotEmpty == true ? user!.lastName![0] : '';
+    final nameParts = user.name!.trim().split(' ');
+    final firstInitial = nameParts.isNotEmpty ? nameParts.first[0] : '';
+    final lastInitial = nameParts.length > 1 ? nameParts.last[0] : '';
 
     return '$firstInitial$lastInitial'.toUpperCase();
   }

--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
@@ -114,20 +114,24 @@ class ChatMessageInternalState extends State<ChatMessageInternal> {
           index < messages.length - 1 ? messages[index + 1] : null;
       final previousMessage = index > 0 ? messages[index - 1] : null;
 
+      // Get dates
+      final now = DateTime.now();
+      final currentMessageDate = currentMessage.time ?? now;
+      final nextMessageDate = nextMessage?.time ?? now;
+      final previousMessageDate = previousMessage?.time ?? now;
+
       // Check if message is part of a group with next message
       final isGroupedWithNext =
           nextMessage != null &&
           nextMessage.authorId == currentMessage.authorId &&
-          nextMessage.createdAt.difference(currentMessage.createdAt).inSeconds <
+          nextMessageDate.difference(currentMessageDate).inSeconds <
               timeoutInSeconds;
 
       // Check if message is part of a group with previous message
       final isGroupedWithPrevious =
           previousMessage != null &&
           previousMessage.authorId == currentMessage.authorId &&
-          currentMessage.createdAt
-                  .difference(previousMessage.createdAt)
-                  .inSeconds <
+          currentMessageDate.difference(previousMessageDate).inSeconds <
               timeoutInSeconds;
 
       // If not grouped with either message, return null

--- a/packages/flutter_chat_ui/lib/src/simple_text_message.dart
+++ b/packages/flutter_chat_ui/lib/src/simple_text_message.dart
@@ -38,7 +38,7 @@ class SimpleTextMessage extends StatelessWidget {
     this.timeAndStatusPosition = TimeAndStatusPosition.end,
   });
 
-  bool get _isOnlyEmoji => message.isOnlyEmoji == true;
+  bool get _isOnlyEmoji => message.metadata?['isOnlyEmoji'] == true;
 
   @override
   Widget build(BuildContext context) {
@@ -49,12 +49,12 @@ class SimpleTextMessage extends StatelessWidget {
     final timeStyle = _resolveTimeStyle(isSentByMe, theme);
 
     final timeAndStatus =
-        showTime || showStatus
+        showTime || (isSentByMe && showStatus)
             ? TimeAndStatus(
-              createdAt: message.createdAt,
+              time: message.time,
               status: message.status,
               showTime: showTime,
-              showStatus: showStatus,
+              showStatus: isSentByMe && showStatus,
               textStyle: timeStyle,
             )
             : null;
@@ -185,7 +185,7 @@ extension on TextStyle {
 }
 
 class TimeAndStatus extends StatelessWidget {
-  final DateTime createdAt;
+  final DateTime? time;
   final MessageStatus? status;
   final bool showTime;
   final bool showStatus;
@@ -193,7 +193,7 @@ class TimeAndStatus extends StatelessWidget {
 
   const TimeAndStatus({
     super.key,
-    required this.createdAt,
+    required this.time,
     this.status,
     this.showTime = true,
     this.showStatus = true,
@@ -208,8 +208,8 @@ class TimeAndStatus extends StatelessWidget {
       spacing: 2,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (showTime)
-          Text(timeFormat.format(createdAt.toLocal()), style: textStyle),
+        if (showTime && time != null)
+          Text(timeFormat.format(time!.toLocal()), style: textStyle),
         if (showStatus && status != null)
           if (status == MessageStatus.sending)
             SizedBox(

--- a/packages/flyer_chat_file_message/lib/src/flyer_chat_file_message.dart
+++ b/packages/flyer_chat_file_message/lib/src/flyer_chat_file_message.dart
@@ -59,12 +59,12 @@ class FlyerChatFileMessage extends StatelessWidget {
     final timeStyle = _resolveTimeStyle(isSentByMe, theme);
 
     final timeAndStatus =
-        showTime || showStatus
+        showTime || (isSentByMe && showStatus)
             ? TimeAndStatus(
-              createdAt: message.createdAt,
+              time: message.time,
               status: message.status,
               showTime: showTime,
-              showStatus: showStatus,
+              showStatus: isSentByMe && showStatus,
               textStyle: timeStyle,
             )
             : null;
@@ -252,7 +252,7 @@ extension on TextStyle {
 }
 
 class TimeAndStatus extends StatelessWidget {
-  final DateTime createdAt;
+  final DateTime? time;
   final MessageStatus? status;
   final bool showTime;
   final bool showStatus;
@@ -260,7 +260,7 @@ class TimeAndStatus extends StatelessWidget {
 
   const TimeAndStatus({
     super.key,
-    required this.createdAt,
+    required this.time,
     this.status,
     this.showTime = true,
     this.showStatus = true,
@@ -275,8 +275,8 @@ class TimeAndStatus extends StatelessWidget {
       spacing: 2,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (showTime)
-          Text(timeFormat.format(createdAt.toLocal()), style: textStyle),
+        if (showTime && time != null)
+          Text(timeFormat.format(time!.toLocal()), style: textStyle),
         if (showStatus && status != null)
           if (status == MessageStatus.sending)
             SizedBox(

--- a/packages/flyer_chat_image_message/lib/src/flyer_chat_image_message.dart
+++ b/packages/flyer_chat_image_message/lib/src/flyer_chat_image_message.dart
@@ -139,14 +139,15 @@ class FlyerChatImageMessageState extends State<FlyerChatImageMessage>
   @override
   Widget build(BuildContext context) {
     final theme = context.watch<ChatTheme>();
+    final isSentByMe = context.watch<UserID>() == widget.message.authorId;
     final textDirection = Directionality.of(context);
     final timeAndStatus =
-        widget.showTime || widget.showStatus
+        widget.showTime || (isSentByMe && widget.showStatus)
             ? TimeAndStatus(
-              createdAt: widget.message.createdAt,
+              time: widget.message.time,
               status: widget.message.status,
               showTime: widget.showTime,
-              showStatus: widget.showStatus,
+              showStatus: isSentByMe && widget.showStatus,
               backgroundColor:
                   widget.timeBackground == FlyerChatImageMessage._sentinelColor
                       ? Colors.black.withValues(alpha: 0.6)
@@ -298,7 +299,7 @@ class FlyerChatImageMessageState extends State<FlyerChatImageMessage>
 }
 
 class TimeAndStatus extends StatelessWidget {
-  final DateTime createdAt;
+  final DateTime? time;
   final MessageStatus? status;
   final bool showTime;
   final bool showStatus;
@@ -307,7 +308,7 @@ class TimeAndStatus extends StatelessWidget {
 
   const TimeAndStatus({
     super.key,
-    required this.createdAt,
+    required this.time,
     this.status,
     this.showTime = true,
     this.showStatus = true,
@@ -329,8 +330,8 @@ class TimeAndStatus extends StatelessWidget {
         spacing: 2,
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (showTime)
-            Text(timeFormat.format(createdAt.toLocal()), style: textStyle),
+          if (showTime && time != null)
+            Text(timeFormat.format(time!.toLocal()), style: textStyle),
           if (showStatus && status != null)
             if (status == MessageStatus.sending)
               SizedBox(

--- a/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
+++ b/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
@@ -39,7 +39,7 @@ class FlyerChatTextMessage extends StatelessWidget {
     this.timeAndStatusPosition = TimeAndStatusPosition.end,
   });
 
-  bool get _isOnlyEmoji => message.isOnlyEmoji == true;
+  bool get _isOnlyEmoji => message.metadata?['isOnlyEmoji'] == true;
 
   @override
   Widget build(BuildContext context) {
@@ -50,12 +50,12 @@ class FlyerChatTextMessage extends StatelessWidget {
     final timeStyle = _resolveTimeStyle(isSentByMe, theme);
 
     final timeAndStatus =
-        showTime || showStatus
+        showTime || (isSentByMe && showStatus)
             ? TimeAndStatus(
-              createdAt: message.createdAt,
+              time: message.time,
               status: message.status,
               showTime: showTime,
-              showStatus: showStatus,
+              showStatus: isSentByMe && showStatus,
               textStyle: timeStyle,
             )
             : null;
@@ -186,7 +186,7 @@ extension on TextStyle {
 }
 
 class TimeAndStatus extends StatelessWidget {
-  final DateTime createdAt;
+  final DateTime? time;
   final MessageStatus? status;
   final bool showTime;
   final bool showStatus;
@@ -194,7 +194,7 @@ class TimeAndStatus extends StatelessWidget {
 
   const TimeAndStatus({
     super.key,
-    required this.createdAt,
+    required this.time,
     this.status,
     this.showTime = true,
     this.showStatus = true,
@@ -209,8 +209,8 @@ class TimeAndStatus extends StatelessWidget {
       spacing: 2,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (showTime)
-          Text(timeFormat.format(createdAt.toLocal()), style: textStyle),
+        if (showTime && time != null)
+          Text(timeFormat.format(time!.toLocal()), style: textStyle),
         if (showStatus && status != null)
           if (status == MessageStatus.sending)
             SizedBox(


### PR DESCRIPTION
- `createdAt` no longer required in the `Message` model
- `sending` is removed from the `Message` model - add `sending: true` to the `metadata` of the `Message` model for the same behaviour 
- `isOnlyEmoji` is removed from the text message model - add `isOnlyEmoji: true` to the `metadata` of the text message for the same behaviour
- `firstName` and `lastName` is replaced with `name` for the `User` model
- message widgets - hide status for the received messages