### PR TITLE
Fix update operation not persisted in the list

### DIFF
--- a/examples/flyer_chat/lib/hive_chat_controller.dart
+++ b/examples/flyer_chat/lib/hive_chat_controller.dart
@@ -63,7 +63,7 @@ class HiveChatController implements ChatController {
       _box.write(() {
         _box.putAt(index, newMessage.toJson());
         _operationsController.add(
-          ChatOperation.update(actualOldMessage, newMessage),
+          ChatOperation.update(actualOldMessage, newMessage, index),
         );
       });
     }

--- a/examples/flyer_chat/lib/sembast_chat_controller.dart
+++ b/examples/flyer_chat/lib/sembast_chat_controller.dart
@@ -98,7 +98,7 @@ class SembastChatController implements ChatController {
 
       await store.record(record.key).update(database, newMessage.toJson());
       _operationsController.add(
-        ChatOperation.update(actualOldMessage, newMessage),
+        ChatOperation.update(actualOldMessage, newMessage, record.key),
       );
     }
   }

--- a/packages/flutter_chat_core/lib/src/chat_controller/chat_operation.dart
+++ b/packages/flutter_chat_core/lib/src/chat_controller/chat_operation.dart
@@ -46,12 +46,16 @@ class ChatOperation {
       );
 
   /// Creates an update operation.
-  factory ChatOperation.update(Message oldMessage, Message message) =>
-      ChatOperation._(
-        ChatOperationType.update,
-        oldMessage: oldMessage,
-        message: message,
-      );
+  factory ChatOperation.update(
+    Message oldMessage,
+    Message message,
+    int index,
+  ) => ChatOperation._(
+    ChatOperationType.update,
+    oldMessage: oldMessage,
+    message: message,
+    index: index,
+  );
 
   /// Creates a remove operation.
   factory ChatOperation.remove(Message message, int index) =>

--- a/packages/flutter_chat_core/lib/src/chat_controller/in_memory_chat_controller.dart
+++ b/packages/flutter_chat_core/lib/src/chat_controller/in_memory_chat_controller.dart
@@ -135,7 +135,7 @@ class InMemoryChatController
       _messages[index] = newMessage;
       // Emit the operation with the state *before* this update and the new state.
       _operationsController.add(
-        ChatOperation.update(actualOldMessage, newMessage),
+        ChatOperation.update(actualOldMessage, newMessage, index),
       );
     }
   }

--- a/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
@@ -1130,7 +1130,12 @@ class _ChatAnimatedListState extends State<ChatAnimatedList>
             );
             _onInsertedAll(op.index!, op.messages!);
             break;
-          default:
+          case ChatOperationType.update:
+            assert(
+              op.index != null,
+              'Index must be provided when updating a message.',
+            );
+            _oldList[op.index!] = op.message!;
             break;
         }
       }


### PR DESCRIPTION
Hello 

@demchenkoalex 
Sorry this PR complements #756 and sadly requires an API change.

### Motivation

Currently the list does not listen to `ChatOperation.update`. When such an operation happens, all `ChatMessages` listen to it and eventually react updating themselves.

This means if the widget is in memory it will properly update **but** 
- if it is discarded
- then rebuilt
it will use the value at it's index in `_oldList` and this value has not been updated so the value prior to the update will be displayed.

### Discussion

I modified the signature to pass the `index` because usually if a client performs an update he must have calcultated it, like in all your examples.
If we want retrocompatibility we could make it optional and search for the message of correct id in the _oldList but this seemed less efficient.

### Side notes
- I put a log in `ChatMessage` listener while debugging and weirdly on an update operation it was printed several times, not really sure why since I emitted only one event.
