### PR TITLE
fix: add tap callback function for the GptMarkdown link

### DIFF
--- a/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
+++ b/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
@@ -46,6 +46,9 @@ class FlyerChatTextMessage extends StatelessWidget {
   /// Position of the timestamp and status indicator relative to the text.
   final TimeAndStatusPosition timeAndStatusPosition;
 
+  /// The callback function to handle link clicks.
+  final void Function(String url, String title)? onLinkTab;
+
   /// Creates a widget to display a text message.
   const FlyerChatTextMessage({
     super.key,
@@ -62,6 +65,7 @@ class FlyerChatTextMessage extends StatelessWidget {
     this.showTime = true,
     this.showStatus = true,
     this.timeAndStatusPosition = TimeAndStatusPosition.end,
+    this.onLinkTab,
   });
 
   bool get _isOnlyEmoji => message.metadata?['isOnlyEmoji'] == true;
@@ -91,6 +95,7 @@ class FlyerChatTextMessage extends StatelessWidget {
           _isOnlyEmoji
               ? paragraphStyle?.copyWith(fontSize: onlyEmojiFontSize)
               : paragraphStyle,
+      onLinkTab: onLinkTab,
     );
 
     return Container(


### PR DESCRIPTION
Currently when rendering the TextMessage with GptMarkdown, link are formatted well but won't be functional. Goal of this Pull request is to allow to send callback function to GptMarkdown, in order to make the link usable.