### PR TITLE
Feat/reactions

### DIFF
--- a/examples/flyer_chat/lib/pagination.dart
+++ b/examples/flyer_chat/lib/pagination.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:flyer_chat_reactions/flyer_chat_reactions.dart';
 import 'package:provider/provider.dart';
 
 import 'widgets/composer_action_bar.dart';
@@ -21,7 +22,7 @@ class PaginationState extends State<Pagination> {
           final numLines = random.nextInt(4) + 1;
           final text = List.generate(
             numLines,
-            (lineIndex) => 'Message ${i + 1} - Line ${lineIndex + 1}',
+            (lineIndex) => 'Message  ${i + 1} - Line ${lineIndex + 1}',
           ).join('\n');
           return Message.text(
             id: (i + 1).toString(),
@@ -31,10 +32,17 @@ class PaginationState extends State<Pagination> {
               isUtc: true,
             ),
             text: text,
+            reactions: {
+              '👍': ['me'],
+              '👎': ['user2', 'me'],
+              '🥨': ['author'],
+              '👌': ['me', 'user3', 'user4'],
+              '👊': ['me'],
+            },
           );
         }).reversed.toList(),
   );
-  final _currentUser = const User(id: 'me');
+  final _currentUser = const User(id: 'me', name: 'This is me');
 
   MessageID? _lastMessageId;
   bool _hasMore = true;
@@ -46,6 +54,10 @@ class PaginationState extends State<Pagination> {
     super.dispose();
   }
 
+  void _onMessageReaction(int index, String? reaction) {
+    print('reaction: $reaction');
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -53,6 +65,7 @@ class PaginationState extends State<Pagination> {
     return Scaffold(
       appBar: AppBar(title: const Text('Pagination')),
       body: Chat(
+        onMessageReaction: _onMessageReaction,
         builders: Builders(
           chatAnimatedListBuilder: (context, itemBuilder) {
             return ChatAnimatedList(
@@ -179,6 +192,13 @@ class MockDatabase {
         isUtc: true,
       ),
       text: text,
+      reactions: {
+        '👍': ['me'],
+        '👎': ['me'],
+        '🥨': ['author'],
+        '👌': ['me'],
+        '👊': ['me'],
+      },
     );
   });
 

--- a/examples/flyer_chat/pubspec.yaml
+++ b/examples/flyer_chat/pubspec.yaml
@@ -2,7 +2,7 @@ name: flyer_chat
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -42,9 +42,11 @@ dependencies:
   flutter_lorem: ^2.0.0
   flyer_chat_file_message: ^2.1.5
   flyer_chat_image_message: ^2.1.6
+  flyer_chat_reactions: ^0.0.12
   flyer_chat_system_message: ^2.1.5
   flyer_chat_text_message: ^2.2.0
   flyer_chat_text_stream_message: ^2.1.5
+
   google_generative_ai: ^0.4.6
   hive_ce: ^2.11.2
   hive_ce_flutter: ^2.3.1
@@ -76,7 +78,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/flutter_chat_core/lib/src/models/message.dart
+++ b/packages/flutter_chat_core/lib/src/models/message.dart
@@ -8,6 +8,8 @@ import 'link_preview_data.dart';
 part 'message.freezed.dart';
 part 'message.g.dart';
 
+typedef MessageReactions = Map<String, List<UserID>>;
+
 /// Base class for all message types.
 ///
 /// Uses a sealed class hierarchy with Freezed for immutability and union types.
@@ -47,7 +49,7 @@ sealed class Message with _$Message {
     @EpochDateTimeConverter() DateTime? updatedAt,
 
     /// Map of reaction keys to lists of user IDs who reacted.
-    Map<String, List<UserID>>? reactions,
+    MessageReactions? reactions,
 
     /// Additional custom metadata associated with the message.
     Map<String, dynamic>? metadata,

--- a/packages/flutter_chat_ui/lib/flutter_chat_ui.dart
+++ b/packages/flutter_chat_ui/lib/flutter_chat_ui.dart
@@ -14,3 +14,4 @@ export 'src/scroll_to_bottom.dart';
 export 'src/simple_text_message.dart';
 export 'src/utils/composer_height_notifier.dart';
 export 'src/utils/load_more_notifier.dart';
+export 'src/utils/typedefs.dart';

--- a/packages/flutter_chat_ui/lib/src/chat.dart
+++ b/packages/flutter_chat_ui/lib/src/chat.dart
@@ -44,6 +44,9 @@ class Chat extends StatefulWidget {
   /// Callback triggered when a message is long-pressed.
   final OnMessageLongPressCallback? onMessageLongPress;
 
+  /// Callback triggered when a message is reacted.
+  final OnMessageReactionCallback? onMessageReaction;
+
   /// Callback triggered when the attachment button in the composer is tapped.
   final OnAttachmentTapCallback? onAttachmentTap;
 
@@ -72,6 +75,7 @@ class Chat extends StatefulWidget {
     this.onMessageSend,
     this.onMessageTap,
     this.onMessageLongPress,
+    this.onMessageReaction,
     this.onAttachmentTap,
     this.backgroundColor,
     this.decoration,
@@ -136,6 +140,7 @@ class _ChatState extends State<Chat> with WidgetsBindingObserver {
         Provider.value(value: _timeFormat),
         Provider.value(value: widget.onMessageSend),
         Provider.value(value: widget.onMessageTap),
+        Provider.value(value: widget.onMessageReaction),
         Provider.value(value: widget.onMessageLongPress),
         Provider.value(value: widget.onAttachmentTap),
         ChangeNotifierProvider(create: (_) => ComposerHeightNotifier()),

--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flyer_chat_reactions/flyer_chat_reactions.dart';
 import 'package:provider/provider.dart';
 
 import '../utils/typedefs.dart';
@@ -195,6 +196,26 @@ class ChatMessage extends StatelessWidget {
     return messageWidget;
   }
 
+  Widget _addReactions(Widget child, {required bool isSentByMe}) {
+    return Stack(
+      children: [
+        Column(
+          children: [
+            child,
+            // TODO find a better way to determine the height
+            SizedBox(height: 16),
+          ],
+        ),
+        Positioned(
+          bottom: 0,
+          left: isSentByMe ? 8 : 0,
+          right: isSentByMe ? 0 : 8,
+          child: FlyerChatReactions(reactions: message.reactions),
+        ),
+      ],
+    );
+  }
+
   Widget _buildMessage({required bool isSentByMe}) => Column(
     mainAxisSize: MainAxisSize.min,
     crossAxisAlignment:
@@ -209,7 +230,7 @@ class ChatMessage extends StatelessWidget {
             isSentByMe ? sentMessageRowAlignment : receivedMessageRowAlignment,
         children: [
           if (leadingWidget != null) leadingWidget!,
-          Flexible(child: child),
+          Flexible(child: _addReactions(child, isSentByMe: isSentByMe)),
           if (trailingWidget != null) trailingWidget!,
         ],
       ),

--- a/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
+++ b/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
@@ -11,6 +11,10 @@ typedef OnMessageTapCallback =
 typedef OnMessageLongPressCallback =
     void Function(Message message, {int index, LongPressStartDetails details});
 
+/// Callback signature for when a message is reacted.
+typedef OnMessageReactionCallback =
+    void Function(int index, String? reaction);
+
 /// Callback signature for when the user attempts to send a message.
 /// Provides the [text] entered by the user.
 typedef OnMessageSendCallback = void Function(String text);

--- a/packages/flutter_chat_ui/pubspec.yaml
+++ b/packages/flutter_chat_ui/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_chat_core: ^2.3.0
+  flyer_chat_reactions: ^0.0.12
   provider: ^6.1.4
   scrollview_observer: ^1.26.0
 

--- a/packages/flyer_chat_reactions/LICENSE
+++ b/packages/flyer_chat_reactions/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Oleksandr Demchenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flyer_chat_reactions/analysis_options.yaml
+++ b/packages/flyer_chat_reactions/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/flyer_chat_reactions/lib/flyer_chat_reactions.dart
+++ b/packages/flyer_chat_reactions/lib/flyer_chat_reactions.dart
@@ -1,0 +1,1 @@
+export 'src/flyer_chat_reactions.dart';

--- a/packages/flyer_chat_reactions/lib/src/flyer_chat_reactions.dart
+++ b/packages/flyer_chat_reactions/lib/src/flyer_chat_reactions.dart
@@ -9,6 +9,7 @@ import 'helpers/reaction_text.dart';
 import 'helpers/text_size_extension.dart';
 import 'models/reaction.dart';
 import 'widgets/reaction_tile.dart';
+import 'widgets/reactions_list.dart';
 
 /// Direction in which the reactions will grow when there are multiple reactions.
 enum FlyerChatReactionsGrowDirection { left, right }
@@ -153,6 +154,15 @@ class _FlyerChatReactionsState extends State<FlyerChatReactions> {
     return visibleCount;
   }
 
+  void _showReactionList() {
+    showReactionsList(
+      context: context,
+      reactions: _reactions,
+      resolveUser: context.read<ResolveUserCallback>(),
+      userCache: context.read<UserCache>(),
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -222,10 +232,11 @@ class _FlyerChatReactionsState extends State<FlyerChatReactions> {
               borderColor: theme.colors.surface,
               backgroundColor: backgroundColor,
               reactedBackgroundColor: reactedBackgroundColor,
-              reactedByUser: _reactions[i].reactedByUser,
+              reactedByUser: _reactions[i].isReactedByUser(currentUserId),
               onTap: () {
                 onReactionTap?.call(1, _reactions[i].emoji);
               },
+              onLongPress: () => _showReactionList,
             ),
           );
         }
@@ -245,6 +256,8 @@ class _FlyerChatReactionsState extends State<FlyerChatReactions> {
               textStyle: _countTextStyle,
               emojiFontSize: widget.emojiFontSize,
               borderColor: theme.colors.surface,
+              onTap: _showReactionList,
+              onLongPress: _showReactionList,
             ),
           );
         }

--- a/packages/flyer_chat_reactions/lib/src/flyer_chat_reactions.dart
+++ b/packages/flyer_chat_reactions/lib/src/flyer_chat_reactions.dart
@@ -1,0 +1,258 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:provider/provider.dart';
+
+import 'helpers/reaction_text.dart';
+import 'helpers/text_size_extension.dart';
+import 'models/reaction.dart';
+import 'widgets/reaction_tile.dart';
+
+/// Direction in which the reactions will grow when there are multiple reactions.
+enum FlyerChatReactionsGrowDirection { left, right }
+
+/// A widget that displays a row of reaction tiles with emojis and counts.
+///
+/// Handles layout and overflow of reactions, showing a surplus count when
+/// there are more reactions than can fit in the available space.
+class FlyerChatReactions extends StatefulWidget {
+  /// The reactions to display, mapped by emoji.
+  final MessageReactions? reactions;
+
+  /// Font size for the emoji in reaction tiles.
+  /// If null, uses the default size.
+  final double? emojiFontSize;
+
+  /// Text style for the count text in reaction tiles.
+  /// If null, uses the default style.
+  final TextStyle? countTextStyle;
+
+  /// Direction in which reactions will grow when there are multiple reactions.
+  /// Defaults to [FlyerChatReactionsGrowDirection.right].
+  final FlyerChatReactionsGrowDirection growDirection;
+
+  /// Space between reaction tiles.
+  /// Defaults to 2.
+  final double spacing;
+
+  /// Padding for each reaction tile.
+  /// Defaults to EdgeInsets.zero.
+  final EdgeInsets reactionTilePadding;
+
+  /// Minimum width for each reaction tile.
+  final double? minimumReactionTileWidth;
+
+  /// Color of the border around reaction tiles.
+  /// If null, uses the default theme color.
+  final Color? borderColor;
+
+  /// Background color for reaction tiles when not reacted by the user.
+  /// If null, uses the default theme color.
+  final Color? reactionBackgroundColor;
+
+  /// Background color for reaction tiles when reacted by the user.
+  /// If null, uses the default theme color.
+  final Color? reactionReactedBackgroundColor;
+
+  /// Creates a widget that displays a row of reaction tiles.
+  const FlyerChatReactions({
+    super.key,
+    this.reactions,
+    this.emojiFontSize,
+    this.countTextStyle,
+    this.spacing = 2,
+    this.reactionTilePadding = EdgeInsets.zero,
+    this.minimumReactionTileWidth = 40,
+    this.borderColor,
+    this.growDirection = FlyerChatReactionsGrowDirection.left,
+    this.reactionBackgroundColor,
+    this.reactionReactedBackgroundColor,
+  });
+
+  @override
+  State<FlyerChatReactions> createState() => _FlyerChatReactionsState();
+}
+
+class _FlyerChatReactionsState extends State<FlyerChatReactions> {
+  /// Text style for the count text, initialized with default or provided style.
+  late final TextStyle _countTextStyle;
+
+  /// List of reactions to display, processed from the input reactions.
+  late List<Reaction> _reactions;
+
+  /// List of calculated sizes for each reaction tile.
+  final reactionsSizes = <Size>[];
+
+  /// Maximum height among all reaction tiles.
+  double maxReactionHeight = 0;
+
+  /// Estimates the size needed for a reaction tile based on its content.
+  Size estimateReactionTileSizeUsingPainter({
+    required String? emoji,
+    required String? text,
+  }) {
+    var emojiSize = Size(0, 0);
+    if (emoji != null) {
+      emojiSize = emoji.getPaintedSize(
+        context,
+        TextStyle(fontSize: widget.emojiFontSize),
+      );
+    }
+    final height = emojiSize.height;
+
+    Size? textSize;
+    if (text != null && text.isNotEmpty) {
+      textSize = text.getPaintedSize(context, _countTextStyle);
+    }
+    final isOnlyEmoji = text == null || text.isEmpty;
+    final totalWidth =
+        widget.reactionTilePadding.horizontal +
+        emojiSize.width +
+        (isOnlyEmoji ? 2.5 : 0) + // Emoji offset fix
+        (textSize?.width ?? 0) +
+        4; // Safety margin for pixel rounding
+    final maxHeight = max(height, textSize?.height ?? 0);
+    final totalHeight = widget.reactionTilePadding.vertical + maxHeight;
+
+    return Size(
+      max(totalWidth, widget.minimumReactionTileWidth ?? 0),
+      totalHeight,
+    );
+  }
+
+  /// Calculates how many reactions can fit in the available width.
+  ///
+  /// Also updates [reactionsSizes] and [maxReactionHeight] with the
+  /// calculated sizes for each visible reaction.
+  ///
+  /// Returns the number of reactions that can be displayed.
+  int calculateSizesAndMaxCapacity(double stackWidth) {
+    reactionsSizes.clear();
+    double usedWidth = 0;
+    var visibleCount = 0;
+    final widgetCount = _reactions.length;
+
+    for (var i = 0; i < widgetCount; i++) {
+      final nextSize = estimateReactionTileSizeUsingPainter(
+        emoji: _reactions[i].emoji,
+        text: getReactionText(_reactions[i].count),
+      );
+      final spaceNeeded =
+          usedWidth + nextSize.width + (visibleCount > 0 ? widget.spacing : 0);
+      if (spaceNeeded < stackWidth) {
+        usedWidth = spaceNeeded;
+        visibleCount++;
+        reactionsSizes.add(nextSize);
+        maxReactionHeight = max(maxReactionHeight, nextSize.height);
+      } else {
+        break;
+      }
+    }
+    return visibleCount;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _countTextStyle =
+        widget.countTextStyle ??
+        TextStyle(fontSize: 10, fontWeight: FontWeight.bold);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.watch<ChatTheme>();
+    final currentUserId = context.watch<UserID>();
+    final onReactionTap = context.read<OnMessageReactionCallback?>();
+    _reactions = reactionsFromMessageReactions(
+      reactions: widget.reactions ?? {},
+      currentUserId: currentUserId,
+    );
+
+    final reactedBackgroundColor =
+        widget.reactionReactedBackgroundColor ??
+        theme.colors.surfaceContainerHigh;
+    final backgroundColor =
+        widget.reactionBackgroundColor ?? theme.colors.surfaceContainerLow;
+
+    return LayoutBuilder(
+      builder: (context, BoxConstraints constraints) {
+        final isNotEnoughSpace =
+            constraints.maxWidth <= 0 || constraints.maxHeight <= 0;
+        if (isNotEnoughSpace) {
+          return const SizedBox.shrink();
+        }
+
+        final stackWidth = constraints.maxWidth;
+
+        var maxCapacity = calculateSizesAndMaxCapacity(stackWidth);
+        var visibleItemsCount = reactionsSizes.length;
+        var hiddenCount = _reactions.length - maxCapacity;
+        final souldDisplaySurplus = hiddenCount > 0;
+
+        Size? surplusWidgetSize;
+        if (souldDisplaySurplus) {
+          surplusWidgetSize = estimateReactionTileSizeUsingPainter(
+            emoji: null,
+            text: '+$hiddenCount',
+          );
+          maxCapacity = calculateSizesAndMaxCapacity(
+            stackWidth - surplusWidgetSize.width - widget.spacing,
+          );
+
+          visibleItemsCount = reactionsSizes.length;
+          hiddenCount = _reactions.length - visibleItemsCount;
+        }
+
+        final children = <Widget>[];
+
+        for (var i = 0; i < visibleItemsCount; i++) {
+          if (i > 0) children.add(SizedBox(width: widget.spacing));
+          children.add(
+            ReactionTile(
+              width: reactionsSizes[i].width,
+              height: maxReactionHeight,
+              emoji: _reactions[i].emoji,
+              count: _reactions[i].count,
+              padding: widget.reactionTilePadding,
+              textStyle: _countTextStyle,
+              emojiFontSize: widget.emojiFontSize,
+              borderColor: theme.colors.surface,
+              backgroundColor: backgroundColor,
+              reactedBackgroundColor: reactedBackgroundColor,
+              reactedByUser: _reactions[i].reactedByUser,
+              onTap: () {
+                onReactionTap?.call(1, _reactions[i].emoji);
+              },
+            ),
+          );
+        }
+
+        if (souldDisplaySurplus) {
+          children.add(SizedBox(width: widget.spacing));
+          children.add(
+            ReactionTile(
+              width: surplusWidgetSize!.width,
+              height: maxReactionHeight,
+              emoji: null,
+              extraText: '+$hiddenCount',
+              padding: widget.reactionTilePadding,
+              backgroundColor: backgroundColor,
+              reactedBackgroundColor: reactedBackgroundColor,
+              reactedByUser: false,
+              textStyle: _countTextStyle,
+              emojiFontSize: widget.emojiFontSize,
+              borderColor: theme.colors.surface,
+            ),
+          );
+        }
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [Row(children: children)],
+        );
+      },
+    );
+  }
+}

--- a/packages/flyer_chat_reactions/lib/src/helpers/reaction_text.dart
+++ b/packages/flyer_chat_reactions/lib/src/helpers/reaction_text.dart
@@ -1,0 +1,3 @@
+String getReactionText(int count) {
+  return count > 1 ? '$count' : '';
+}

--- a/packages/flyer_chat_reactions/lib/src/helpers/text_size_extension.dart
+++ b/packages/flyer_chat_reactions/lib/src/helpers/text_size_extension.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+extension TextSize on String {
+  Size getPaintedSize(BuildContext context, TextStyle textStyle) {
+    return (TextPainter(
+      text: TextSpan(text: this, style: textStyle),
+      maxLines: 1,
+      textScaler: MediaQuery.of(context).textScaler,
+      textDirection: TextDirection.ltr,
+    )..layout()).size;
+  }
+}

--- a/packages/flyer_chat_reactions/lib/src/models/reaction.dart
+++ b/packages/flyer_chat_reactions/lib/src/models/reaction.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+
+class Reaction {
+  final String emoji;
+  final int count;
+  final bool reactedByUser;
+
+  Reaction({
+    required this.emoji,
+    required this.count,
+    required this.reactedByUser,
+  });
+}
+
+/// Converts a map of reactions to a list of [Reaction] objects
+///
+/// [reactions] is a map [MessageReactions] where keys are emoji strings and values are lists of user IDs
+/// [currentUserId] is used to determine if the current user has reacted
+List<Reaction> reactionsFromMessageReactions({
+  required MessageReactions reactions,
+  required String currentUserId,
+}) {
+  return reactions.entries.map((entry) {
+    final emoji = entry.key;
+    final userIds = entry.value;
+    return Reaction(
+      emoji: emoji,
+      count: userIds.length,
+      reactedByUser: userIds.contains(currentUserId),
+    );
+  }).toList();
+}

--- a/packages/flyer_chat_reactions/lib/src/models/reaction.dart
+++ b/packages/flyer_chat_reactions/lib/src/models/reaction.dart
@@ -2,14 +2,13 @@ import 'package:flutter_chat_core/flutter_chat_core.dart';
 
 class Reaction {
   final String emoji;
-  final int count;
-  final bool reactedByUser;
+  final List<String> userIds;
 
-  Reaction({
-    required this.emoji,
-    required this.count,
-    required this.reactedByUser,
-  });
+  const Reaction({required this.emoji, required this.userIds});
+
+  int get count => userIds.length;
+
+  bool isReactedByUser(String userId) => userIds.contains(userId);
 }
 
 /// Converts a map of reactions to a list of [Reaction] objects
@@ -23,10 +22,6 @@ List<Reaction> reactionsFromMessageReactions({
   return reactions.entries.map((entry) {
     final emoji = entry.key;
     final userIds = entry.value;
-    return Reaction(
-      emoji: emoji,
-      count: userIds.length,
-      reactedByUser: userIds.contains(currentUserId),
-    );
+    return Reaction(emoji: emoji, userIds: userIds);
   }).toList();
 }

--- a/packages/flyer_chat_reactions/lib/src/widgets/reaction_tile.dart
+++ b/packages/flyer_chat_reactions/lib/src/widgets/reaction_tile.dart
@@ -33,6 +33,10 @@ class ReactionTile extends StatefulWidget {
   /// Used to handle reaction selection/deselection.
   final VoidCallback? onTap;
 
+  /// Callback triggered when the reaction tile is long pressed.
+  /// Used to handle additional actions like showing a menu or details.
+  final VoidCallback? onLongPress;
+
   /// Background color for the reaction tile when not reacted by the user.
   /// If null, uses the default theme color.
   final Color? backgroundColor;
@@ -77,6 +81,7 @@ class ReactionTile extends StatefulWidget {
     this.extraText,
     this.reactedByUser = false,
     this.onTap,
+    this.onLongPress,
     this.backgroundColor,
     this.reactedBackgroundColor,
     this.borderColor,
@@ -125,7 +130,7 @@ class _ReactionTileState extends State<ReactionTile> {
           }
           widget.onTap?.call();
         },
-
+        onLongPress: widget.onLongPress,
         child: Container(
           padding: widget.padding,
           decoration: BoxDecoration(

--- a/packages/flyer_chat_reactions/lib/src/widgets/reaction_tile.dart
+++ b/packages/flyer_chat_reactions/lib/src/widgets/reaction_tile.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+import '../helpers/reaction_text.dart';
+
+/// A widget that displays a reaction with an emoji and optional count.
+///
+/// Used to show individual reactions in the chat interface, supporting both
+/// single emoji reactions, reactions with counts or a text (for surplus)
+
+class ReactionTile extends StatefulWidget {
+  /// The emoji to display as the reaction.
+  final String? emoji;
+
+  /// The count of reactions for this emoji.
+  /// If null, the count is not shown.
+  /// If 0, the tile is not shown.
+  final int? count;
+
+  /// The minimum count required to display the count text.
+  /// If count is less than this value, count text will not be shown.
+  /// Defaults to 2.
+  final int countDisplayThreshold;
+
+  /// The text to display, after the count text.
+  /// Typically used for surplus reactions.
+  final String? extraText;
+
+  /// Whether this reaction was added by the current user.
+  /// Affects the visual styling of the tile.
+  final bool reactedByUser;
+
+  /// Callback triggered when the reaction tile is tapped.
+  /// Used to handle reaction selection/deselection.
+  final VoidCallback? onTap;
+
+  /// Background color for the reaction tile when not reacted by the user.
+  /// If null, uses the default theme color.
+  final Color? backgroundColor;
+
+  /// Background color for the reaction tile when reacted by the user.
+  /// If null, uses the default theme color.
+  final Color? reactedBackgroundColor;
+
+  /// Color of the border around the reaction tile.
+  final Color? borderColor;
+
+  /// Text style for the count text and extra text.
+  /// If null, uses the default style.
+  final TextStyle? textStyle;
+
+  /// Font size for the emoji.
+  /// If null, uses the default size.
+  final double? emojiFontSize;
+
+  /// Space between the emoji and the count text.
+  /// Defaults to 0.
+  final double spaceBetweenEmojiAndCount;
+
+  /// Fixed width for the reaction tile.
+  /// If null, the tile will size itself based on its content.
+  final double? width;
+
+  /// Fixed height for the reaction tile.
+  /// If null, the tile will size itself based on its content.
+  final double? height;
+
+  /// Padding around the content of the reaction tile.
+  /// If null, uses default container padding.
+  final EdgeInsets? padding;
+
+  /// Creates a reaction tile widget.
+  const ReactionTile({
+    super.key,
+    this.emoji,
+    this.count,
+    this.countDisplayThreshold = 2,
+    this.extraText,
+    this.reactedByUser = false,
+    this.onTap,
+    this.backgroundColor,
+    this.reactedBackgroundColor,
+    this.borderColor,
+    this.textStyle,
+    this.emojiFontSize,
+    this.spaceBetweenEmojiAndCount = 0,
+    this.width,
+    this.height,
+    this.padding,
+  });
+
+  @override
+  State<ReactionTile> createState() => _ReactionTileState();
+}
+
+class _ReactionTileState extends State<ReactionTile> {
+  late bool _isTapped;
+  late int? _count;
+
+  @override
+  void initState() {
+    super.initState();
+    _count = widget.count;
+    _isTapped = widget.reactedByUser;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isOnlyEmoji = widget.extraText == null || widget.extraText!.isEmpty;
+    if (_count == 0) {
+      return const SizedBox.shrink();
+    }
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: GestureDetector(
+        onTap: () {
+          if (widget.count != null) {
+            setState(() {
+              _count = _count! + (_isTapped ? -1 : 1);
+              _isTapped = !_isTapped;
+              // TODO the widget rebuilds locally
+              // but maybe we should notify the parent (maybe only if the count is 0 or count.toString().length is different)
+              // To redraw all reactions
+            });
+          }
+          widget.onTap?.call();
+        },
+
+        child: Container(
+          padding: widget.padding,
+          decoration: BoxDecoration(
+            color:
+                widget.reactedByUser
+                    ? widget.reactedBackgroundColor
+                    : widget.backgroundColor,
+            borderRadius: BorderRadius.circular(16),
+            border:
+                widget.borderColor != null
+                    ? Border.all(color: widget.borderColor!, width: 1)
+                    : null,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.emoji != null)
+                /// Emoji alignement issue https://github.com/flutter/flutter/issues/119623
+                Padding(
+                  padding: EdgeInsets.fromLTRB(isOnlyEmoji ? 2.5 : 0, 0, 0, 3),
+                  child: Text(
+                    widget.emoji!,
+                    style: TextStyle(fontSize: widget.emojiFontSize),
+                  ),
+                ),
+              if (_count != null && _count! >= widget.countDisplayThreshold)
+                Text(getReactionText(_count!), style: widget.textStyle),
+              if (widget.extraText != null)
+                Text(widget.extraText!, style: widget.textStyle),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flyer_chat_reactions/lib/src/widgets/reactions_list.dart
+++ b/packages/flyer_chat_reactions/lib/src/widgets/reactions_list.dart
@@ -1,0 +1,260 @@
+import 'dart:ffi';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:provider/provider.dart';
+
+import '../models/reaction.dart';
+import 'reaction_tile.dart';
+
+/// A widget that displays a list of users and their reactions in a bottom sheet.
+///
+/// Used to show who reacted with which emoji, typically shown when long-pressing
+/// a reaction tile.
+class ReactionsList extends StatefulWidget {
+  /// The list of reactions to display.
+  final List<Reaction> reactions;
+
+  /// The style for the user ID text.
+  final TextStyle? userTextStyle;
+
+  /// The style for the reaction count text.
+  final TextStyle? countTextStyle;
+
+  /// Font size for the emoji in reaction tiles.
+  final double? emojiFontSize;
+
+  /// Background color for the bottom sheet.
+  final Color? backgroundColor;
+
+  /// Callback to resolve user names.
+  final ResolveUserCallback? resolveUser;
+
+  /// Cache for user names.
+  final UserCache? userCache;
+
+  /// Creates a widget that displays a list of users and their reactions.
+  const ReactionsList({
+    super.key,
+    required this.reactions,
+    this.userTextStyle,
+    this.countTextStyle,
+    this.emojiFontSize,
+    this.backgroundColor,
+    this.resolveUser,
+    this.userCache,
+  });
+
+  @override
+  State<ReactionsList> createState() => _ReactionsListState();
+}
+
+class _ReactionsListState extends State<ReactionsList> {
+  String? selectedEmoji;
+
+  Future<Map<String, String>> _resolveUserNames(BuildContext context) async {
+    final userMap = <String, String>{};
+    for (final reaction in widget.reactions) {
+      for (final userId in reaction.userIds) {
+        if (!userMap.containsKey(userId) && widget.resolveUser != null) {
+          final resolvedUser = await widget.userCache?.getOrResolve(
+            userId,
+            widget.resolveUser!,
+          );
+          userMap[userId] = resolvedUser?.name ?? userId;
+        }
+      }
+    }
+    return userMap;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final filteredReactions =
+        selectedEmoji == null
+            ? widget.reactions
+            : widget.reactions.where((r) => r.emoji == selectedEmoji).toList();
+
+    return Container(
+      clipBehavior: Clip.hardEdge,
+      decoration: BoxDecoration(
+        color: widget.backgroundColor ?? theme.colorScheme.surface,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(28),
+          topRight: Radius.circular(28),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Header
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: theme.colorScheme.outline.withOpacity(0.2),
+                ),
+              ),
+            ),
+            child: Row(
+              children: [
+                Text('Reactions', style: theme.textTheme.titleMedium),
+                const Spacer(),
+                Text(
+                  '${widget.reactions.fold(0, (sum, r) => sum + r.count)}',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Filter chips
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                FilterChip(
+                  label: const Text('All'),
+                  selected: selectedEmoji == null,
+                  onSelected: (selected) {
+                    setState(() {
+                      selectedEmoji = null;
+                    });
+                  },
+                ),
+                const SizedBox(width: 8),
+                ...widget.reactions.map(
+                  (reaction) => Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: FilterChip(
+                      label: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(reaction.emoji),
+                          const SizedBox(width: 4),
+                          Text('${reaction.count}'),
+                        ],
+                      ),
+                      selected: selectedEmoji == reaction.emoji,
+                      onSelected: (selected) {
+                        setState(() {
+                          selectedEmoji = selected ? reaction.emoji : null;
+                        });
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Reactions list
+          Flexible(
+            child: FutureBuilder<Map<String, String>>(
+              future: _resolveUserNames(context),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(16.0),
+                      child: CircularProgressIndicator(),
+                    ),
+                  );
+                }
+
+                final userMap = snapshot.data ?? {};
+
+                return SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.4,
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: filteredReactions.length,
+                    itemBuilder: (context, index) {
+                      final reaction = filteredReactions[index];
+
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                            child: Row(
+                              children: [
+                                Text(
+                                  reaction.emoji,
+                                  style: TextStyle(
+                                    fontSize: widget.emojiFontSize,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  '${reaction.count}',
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(
+                              left: 16.0,
+                              right: 16.0,
+                              bottom: 4,
+                            ),
+                            child: Text(
+                              reaction.userIds
+                                  .map((userId) => userMap[userId] ?? userId)
+                                  .join(', '),
+                              style:
+                                  widget.userTextStyle ??
+                                  theme.textTheme.bodyMedium,
+                            ),
+                          ),
+                          if (index < filteredReactions.length - 1)
+                            Divider(
+                              height: 1,
+                              color: theme.colorScheme.outline.withAlpha(60),
+                            ),
+                        ],
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shows a bottom sheet with the list of reactions.
+Future<void> showReactionsList({
+  required BuildContext context,
+  required List<Reaction> reactions,
+  TextStyle? userTextStyle,
+  TextStyle? countTextStyle,
+  double? emojiFontSize,
+  Color? backgroundColor,
+  ResolveUserCallback? resolveUser,
+  UserCache? userCache,
+}) {
+  return showModalBottomSheet(
+    context: context,
+    backgroundColor: Colors.transparent,
+    builder:
+        (context) => ReactionsList(
+          reactions: reactions,
+          userTextStyle: userTextStyle,
+          countTextStyle: countTextStyle,
+          emojiFontSize: emojiFontSize,
+          backgroundColor: backgroundColor,
+          resolveUser: resolveUser,
+          userCache: userCache,
+        ),
+  );
+}

--- a/packages/flyer_chat_reactions/pubspec.yaml
+++ b/packages/flyer_chat_reactions/pubspec.yaml
@@ -1,0 +1,22 @@
+name: flyer_chat_reactions
+version: 0.0.12
+description: >
+  Reactions package for Flutter chat apps, complementing flutter_chat_ui. #chat #ui
+homepage: https://flyer.chat
+repository: https://github.com/flyerhq/flutter_chat_ui
+
+environment:
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_chat_core: ^2.2.1
+  flutter_chat_ui: ^2.2.3
+  provider: ^6.1.4
+
+dev_dependencies:
+  flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter


### PR DESCRIPTION
# Motivation

This is a first - partial - attemp to add reactions support to FlyerChat.
I raises a few architecture questions to discuss.


# Implementation
Currently the implementation is mostly based on 3 widgets
- `ReactionTile` represent a small bubble with the emoji and count
- `FlyerChatReactions` lays them out based on the available space + size calculations
- `ReactionList` displays all the reactions

I made my best to avoid using `InstrinsicSizes` for performance

# Questions

1. I opted for the Signal/Whatsapp style (and not something like Telegram)
2. Need to decide how to trigger reactions, since `onLongPressed` is already exposed at the `Chat` level


#  Know issues

1. Currently each `ReactionTile` handles it's internal state but this means the parent `FlyerChatReactions` can't eventually recalculate position to hide/display a new reaction
3. Needs a better way to manage the reaction height

# TODO

**Arch**
- [ ] Add a `reactionBuilder`: should it be a parameter of `ChatMessage` or Chat?; should `ChatMessage` use one by default?

**Ui**

- [ ] Cleanup customization options
- [ ] Make reactions list sexier
- [ ] Insertion animations? That would be for you alex :) Relates to the know issue above, maybe the tile should notify a count change and the Parent widget should redraw with style. I'm not used to flutter animations / list inserts

**Feat**

- [ ] Implement add reaction. I was thinking something like https://pub.dev/packages/flutter_chat_reactions is quite smart. Maybe not use the package but do something similar.

https://github.com/user-attachments/assets/2b76f77d-31a8-4815-a347-182f062a1b6f






