### PR TITLE
Expose isSentByMe and groupStatus in all messages builders

### DIFF
--- a/examples/flyer_chat/lib/api/api.dart
+++ b/examples/flyer_chat/lib/api/api.dart
@@ -87,11 +87,21 @@ class ApiState extends State<Api> {
           Chat(
             builders: Builders(
               textMessageBuilder:
-                  (context, message, index) =>
-                      FlyerChatTextMessage(message: message, index: index),
+                  (
+                    context,
+                    message,
+                    index, {
+                    required bool isSentByMe,
+                    MessageGroupStatus? groupStatus,
+                  }) => FlyerChatTextMessage(message: message, index: index),
               imageMessageBuilder:
-                  (context, message, index) =>
-                      FlyerChatImageMessage(message: message, index: index),
+                  (
+                    context,
+                    message,
+                    index, {
+                    required bool isSentByMe,
+                    MessageGroupStatus? groupStatus,
+                  }) => FlyerChatImageMessage(message: message, index: index),
               composerBuilder:
                   (context) => Composer(
                     topWidget: ComposerActionBar(

--- a/examples/flyer_chat/lib/gemini.dart
+++ b/examples/flyer_chat/lib/gemini.dart
@@ -147,7 +147,13 @@ class GeminiState extends State<Gemini> {
               );
             },
             imageMessageBuilder:
-                (context, message, index) => FlyerChatImageMessage(
+                (
+                  context,
+                  message,
+                  index, {
+                  required bool isSentByMe,
+                  MessageGroupStatus? groupStatus,
+                }) => FlyerChatImageMessage(
                   message: message,
                   index: index,
                   showTime: false,
@@ -172,7 +178,13 @@ class GeminiState extends State<Gemini> {
                   ),
                 ),
             textMessageBuilder:
-                (context, message, index) => FlyerChatTextMessage(
+                (
+                  context,
+                  message,
+                  index, {
+                  required bool isSentByMe,
+                  MessageGroupStatus? groupStatus,
+                }) => FlyerChatTextMessage(
                   message: message,
                   index: index,
                   showTime: false,
@@ -186,7 +198,13 @@ class GeminiState extends State<Gemini> {
                             vertical: 10,
                           ),
                 ),
-            textStreamMessageBuilder: (context, message, index) {
+            textStreamMessageBuilder: (
+              context,
+              message,
+              index, {
+              required bool isSentByMe,
+              MessageGroupStatus? groupStatus,
+            }) {
               // Watch the manager for state updates
               final streamState = context.watch<GeminiStreamManager>().getState(
                 message.streamId,

--- a/examples/flyer_chat/lib/local.dart
+++ b/examples/flyer_chat/lib/local.dart
@@ -70,7 +70,13 @@ class LocalState extends State<Local> {
             );
           },
           customMessageBuilder:
-              (context, message, index) => Container(
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                MessageGroupStatus? groupStatus,
+              }) => Container(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
                   vertical: 10,
@@ -85,11 +91,21 @@ class LocalState extends State<Local> {
                 child: IsTypingIndicator(),
               ),
           imageMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatImageMessage(message: message, index: index),
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                MessageGroupStatus? groupStatus,
+              }) => FlyerChatImageMessage(message: message, index: index),
           systemMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatSystemMessage(message: message, index: index),
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                MessageGroupStatus? groupStatus,
+              }) => FlyerChatSystemMessage(message: message, index: index),
           composerBuilder:
               (context) => Composer(
                 topWidget: ComposerActionBar(
@@ -114,11 +130,21 @@ class LocalState extends State<Local> {
                 ),
               ),
           textMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatTextMessage(message: message, index: index),
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                MessageGroupStatus? groupStatus,
+              }) => FlyerChatTextMessage(message: message, index: index),
           fileMessageBuilder:
-              (context, message, index) =>
-                  FlyerChatFileMessage(message: message, index: index),
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                MessageGroupStatus? groupStatus,
+              }) => FlyerChatFileMessage(message: message, index: index),
           chatMessageBuilder: (
             context,
             message,
@@ -126,6 +152,7 @@ class LocalState extends State<Local> {
             animation,
             child, {
             bool? isRemoved,
+            required bool isSentByMe,
             MessageGroupStatus? groupStatus,
           }) {
             final isSystemMessage = message.authorId == 'system';

--- a/packages/flutter_chat_core/lib/src/models/builders.dart
+++ b/packages/flutter_chat_core/lib/src/models/builders.dart
@@ -8,39 +8,93 @@ part 'builders.freezed.dart';
 
 /// Signature for building a text message widget.
 typedef TextMessageBuilder =
-    Widget Function(BuildContext, TextMessage, int index);
+    Widget Function(
+      BuildContext,
+      TextMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building a streaming text message widget.
 typedef TextStreamMessageBuilder =
-    Widget Function(BuildContext, TextStreamMessage, int index);
+    Widget Function(
+      BuildContext,
+      TextStreamMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building an image message widget.
 typedef ImageMessageBuilder =
-    Widget Function(BuildContext, ImageMessage, int index);
+    Widget Function(
+      BuildContext,
+      ImageMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building a file message widget.
 typedef FileMessageBuilder =
-    Widget Function(BuildContext, FileMessage, int index);
+    Widget Function(
+      BuildContext,
+      FileMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building a video message widget.
 typedef VideoMessageBuilder =
-    Widget Function(BuildContext, VideoMessage, int index);
+    Widget Function(
+      BuildContext,
+      VideoMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building an audio message widget.
 typedef AudioMessageBuilder =
-    Widget Function(BuildContext, AudioMessage, int index);
+    Widget Function(
+      BuildContext,
+      AudioMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building a system message widget.
 typedef SystemMessageBuilder =
-    Widget Function(BuildContext, SystemMessage, int index);
+    Widget Function(
+      BuildContext,
+      SystemMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building a custom message widget.
 typedef CustomMessageBuilder =
-    Widget Function(BuildContext, CustomMessage, int index);
+    Widget Function(
+      BuildContext,
+      CustomMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building an unsupported message widget.
 typedef UnsupportedMessageBuilder =
-    Widget Function(BuildContext, UnsupportedMessage, int index);
+    Widget Function(
+      BuildContext,
+      UnsupportedMessage,
+      int index, {
+      required bool isSentByMe,
+      MessageGroupStatus? groupStatus,
+    });
 
 /// Signature for building the message composer widget.
 typedef ComposerBuilder = Widget Function(BuildContext);
@@ -54,6 +108,7 @@ typedef ChatMessageBuilder =
       Animation<double> animation,
       Widget child, {
       bool? isRemoved,
+      required bool isSentByMe,
       MessageGroupStatus? groupStatus,
     });
 

--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
@@ -90,14 +90,18 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
   @override
   Widget build(BuildContext context) {
     final builders = context.read<Builders>();
+
+    final groupStatus = _resolveGroupStatus(context);
+    final isSentByMe = context.watch<UserID>() == _updatedMessage.authorId;
+
     final child = _buildMessage(
       context,
       builders,
       _updatedMessage,
       widget.index,
+      isSentByMe,
+      groupStatus,
     );
-
-    final groupStatus = _resolveGroupStatus(context);
 
     return builders.chatMessageBuilder?.call(
           context,
@@ -106,6 +110,7 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
           widget.animation,
           child,
           isRemoved: widget.isRemoved,
+          isSentByMe: isSentByMe,
           groupStatus: groupStatus,
         ) ??
         ChatMessage(
@@ -171,21 +176,37 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
     Builders builders,
     Message message,
     int index,
+    bool isSentByMe,
+    MessageGroupStatus? groupStatus,
   ) {
     switch (message) {
       case TextMessage():
-        return builders.textMessageBuilder?.call(context, message, index) ??
+        return builders.textMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             SimpleTextMessage(message: message, index: index);
       case TextStreamMessage():
         return builders.textStreamMessageBuilder?.call(
               context,
               message,
               index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
             ) ??
             const SizedBox.shrink();
       case ImageMessage():
         final result =
-            builders.imageMessageBuilder?.call(context, message, index) ??
+            builders.imageMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
         assert(
           !(result is SizedBox && result.width == 0 && result.height == 0),
@@ -195,25 +216,57 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
         );
         return result;
       case FileMessage():
-        return builders.fileMessageBuilder?.call(context, message, index) ??
+        return builders.fileMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
       case VideoMessage():
-        return builders.videoMessageBuilder?.call(context, message, index) ??
+        return builders.videoMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
       case AudioMessage():
-        return builders.audioMessageBuilder?.call(context, message, index) ??
+        return builders.audioMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
       case SystemMessage():
-        return builders.systemMessageBuilder?.call(context, message, index) ??
+        return builders.systemMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
       case CustomMessage():
-        return builders.customMessageBuilder?.call(context, message, index) ??
+        return builders.customMessageBuilder?.call(
+              context,
+              message,
+              index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
+            ) ??
             const SizedBox.shrink();
       case UnsupportedMessage():
         return builders.unsupportedMessageBuilder?.call(
               context,
               message,
               index,
+              isSentByMe: isSentByMe,
+              groupStatus: groupStatus,
             ) ??
             const Text(
               'This message is not supported. Please update your app.',


### PR DESCRIPTION
Exposing those 2 attributes in the builders, allow for more customization


For example only showing Time/status for the last message of the group

```dart
            textMessageBuilder: (
                context,
                message,
                index, {
                required bool isSentByMe,
                MessageGroupStatus? groupStatus,
              }) =>
                  FlyerChatTextMessage(
                message: message,
                index: index,
                showStatus: _shouldDisplayStatus(groupStatus),
                showTime: _shouldDisplayTime(groupStatus),
              ),
```


Note: I choose not to remove the `isSentByMe` logic inside the UI package (what would require user to pass it manually in each builder)


![image](https://github.com/user-attachments/assets/7e29a445-e744-4d7c-ac72-ffe699b69f90)
