### PR TITLE
Fix composer blank message sending

### DIFF
--- a/packages/flutter_chat_ui/lib/src/composer.dart
+++ b/packages/flutter_chat_ui/lib/src/composer.dart
@@ -302,8 +302,10 @@ class _ComposerState extends State<Composer> {
                             return IconButton(
                               icon: widget.sendIcon!,
                               color: iconColor,
-                              onPressed:
-                                  () => _handleSubmitted(_textController.text),
+                              onPressed: hasText
+                                  ? () =>
+                                      _handleSubmitted(_textController.text)
+                                  : null,
                             );
                           },
                         )
@@ -334,8 +336,9 @@ class _ComposerState extends State<Composer> {
   }
 
   void _handleSubmitted(String text) {
-    if (text.isNotEmpty) {
-      context.read<OnMessageSendCallback?>()?.call(text);
+    final trimmed = text.trim();
+    if (trimmed.isNotEmpty) {
+      context.read<OnMessageSendCallback?>()?.call(trimmed);
       _textController.clear();
     }
   }


### PR DESCRIPTION
## Summary
- prevent sending messages consisting only of whitespace
- disable send button when composer has no text

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format --output=none packages/flutter_chat_ui/lib/src/composer.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b6a8be60832887217145dcdb1a0f