### PR TITLE
Fix cross_cache test description

### DIFF
--- a/packages/cross_cache/test/cross_cache_test.dart
+++ b/packages/cross_cache/test/cross_cache_test.dart
@@ -18,7 +18,7 @@ void main() {
       dioAdapter = DioAdapter(dio: dio);
     });
 
-    test('treats objects with the same properties as equal', () async {
+    test('downloads data using provided headers', () async {
       dioAdapter.onGet(
         path,
         (server) => server.reply(


### PR DESCRIPTION
## Summary
- update test description to reflect behavior

## Testing
- `dart test packages/cross_cache/test/cross_cache_test.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845c111ec4c83288aab56ab939189ec