### PR TITLE
add method OnMessageDoubleTapCallback; add param BuildContext context for OnMessageTapCallback and OnMessageLongPressCallback

### DIFF
--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
@@ -123,6 +123,7 @@ class ChatMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final onMessageTap = context.read<OnMessageTapCallback?>();
+    final onMessageDoubleTap = context.read<OnMessageDoubleTapCallback?>();
     final onMessageLongPress = context.read<OnMessageLongPressCallback?>();
     final isSentByMe = context.read<UserID>() == message.authorId;
 
@@ -153,6 +154,8 @@ class ChatMessage extends StatelessWidget {
                 index: index,
                 details: details,
               ),
+          onDoubleTap:
+              () => onMessageDoubleTap?.call(context, message, index: index),
           onLongPressStart:
               (details) => onMessageLongPress?.call(
                 context,

--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message.dart
@@ -147,10 +147,15 @@ class ChatMessage extends StatelessWidget {
           ),
         GestureDetector(
           onTapUp:
-              (details) =>
-                  onMessageTap?.call(message, index: index, details: details),
+              (details) => onMessageTap?.call(
+                context,
+                message,
+                index: index,
+                details: details,
+              ),
           onLongPressStart:
               (details) => onMessageLongPress?.call(
+                context,
                 message,
                 index: index,
                 details: details,

--- a/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
+++ b/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
@@ -12,6 +12,12 @@ typedef OnMessageTapCallback =
       TapUpDetails details,
     });
 
+/// Callback signature for when a message is double tapped.
+/// [context] is the BuildContext from the widget tree where the tap occurs.
+/// Provides the tapped [message], its [index]
+typedef OnMessageDoubleTapCallback =
+    void Function(BuildContext context, Message message, {int index});
+
 /// Callback signature for when a message is long-pressed.
 /// [context] is the BuildContext from the widget tree where the long press occurs.
 /// Provides the long-pressed [message], its [index], and [LongPressStartDetails].

--- a/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
+++ b/packages/flutter_chat_ui/lib/src/utils/typedefs.dart
@@ -2,14 +2,26 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
 
 /// Callback signature for when a message is tapped.
+/// [context] is the BuildContext from the widget tree where the tap occurs.
 /// Provides the tapped [message], its [index], and [TapUpDetails].
 typedef OnMessageTapCallback =
-    void Function(Message message, {int index, TapUpDetails details});
+    void Function(
+      BuildContext context,
+      Message message, {
+      int index,
+      TapUpDetails details,
+    });
 
 /// Callback signature for when a message is long-pressed.
+/// [context] is the BuildContext from the widget tree where the long press occurs.
 /// Provides the long-pressed [message], its [index], and [LongPressStartDetails].
 typedef OnMessageLongPressCallback =
-    void Function(Message message, {int index, LongPressStartDetails details});
+    void Function(
+      BuildContext context,
+      Message message, {
+      int index,
+      LongPressStartDetails details,
+    });
 
 /// Callback signature for when the user attempts to send a message.
 /// Provides the [text] entered by the user.


### PR DESCRIPTION
add method OnMessageDoubleTapCallback;
add param BuildContext context for OnMessageTapCallback and OnMessageLongPressCallback

The following functions must be in the context of the message widget
```
  // 消息长按事件
  void _onMessageLongPress(
      BuildContext c1,
    Message message, {
    int? index,
    LongPressStartDetails? details,
  }) {
    iPrint('_onMessageLongPress');
    // BuildContext c1 = getx.Get.context!;
    final menu = popupmenu.PopupMenu(
      context: c1,
      items: logic.getPopupMenuItems(message),
      onClickMenu: onClickMenu,
    );

    final renderBox = c1.findRenderObject() as RenderBox;
    final offset = renderBox.localToGlobal(Offset.zero);

    double l = offset.dx / 2 - renderBox.size.width / 2 + 75.0;
    double r = renderBox.size.width / 2 - 75.0;
    double dx = message.authorId == UserRepoLocal.to.currentUid ? r : l;
    double dy = offset.dy.clamp(0, getx.Get.height);
    double h = renderBox.size.height > getx.Get.height
        ? getx.Get.height
        : renderBox.size.height;

    menu.show(rect: Rect.fromLTWH(dx, dy, renderBox.size.width, h));
  }

```