### PR TITLE
Support --wasm builds by adding dart.library.js_interop case to cross_cache

### DIFF
--- a/packages/cross_cache/lib/src/cross_cache.dart
+++ b/packages/cross_cache/lib/src/cross_cache.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart' show rootBundle, Uint8List;
 
 import 'cache/cache.dart'
     if (dart.library.io) 'cache/io.dart'
+    if (dart.library.js_interop) 'cache/html.dart'
     if (dart.library.html) 'cache/html.dart';
 
 /// A cross-platform caching utility for downloading and storing binary data (like images).


### PR DESCRIPTION
dart.library.html is not available for WASM builds, so cross cache currently fails with

`'Cache is not available in your current platform.'`

Since idb_shim is WASM compatible and doesn't rely on html, we can just add dart.library.js_interop to select the web implementation.