### PR TITLE
Add custom status and time builders for flyer_chat widgets

### DIFF
--- a/examples/flyer_chat/macos/Podfile.lock
+++ b/examples/flyer_chat/macos/Podfile.lock
@@ -36,11 +36,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
+  file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   isar_flutter_libs: a65381780401f81ad6bf3f2e7cd0de5698fb98c4
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
+++ b/packages/flyer_chat_text_message/lib/src/flyer_chat_text_message.dart
@@ -81,6 +81,15 @@ class FlyerChatTextMessage extends StatelessWidget {
   /// The widget to display on top of the message.
   final Widget? topWidget;
 
+  /// Builder for the status widget if not provided, will build a default widget with Icons
+  /// Will not be displayed if [showStatus] is false.
+  final Widget Function(BuildContext context, MessageStatus? status)?
+  statusBuilder;
+
+  /// Builder for the time widget, if not provided will build a default widget using the HH:mm format
+  /// Will not be displayed if [showTime] is false.
+  final Widget Function(BuildContext context, DateTime time)? timeBuilder;
+
   /// Creates a widget to display a text message.
   const FlyerChatTextMessage({
     super.key,
@@ -98,7 +107,9 @@ class FlyerChatTextMessage extends StatelessWidget {
     this.receivedLinksColor,
     this.timeStyle,
     this.showTime = true,
+    this.timeBuilder,
     this.showStatus = true,
+    this.statusBuilder,
     this.timeAndStatusPosition = TimeAndStatusPosition.end,
     this.timeAndStatusPositionInlineInsets = const EdgeInsets.only(bottom: 2),
     this.onLinkTap,
@@ -131,7 +142,9 @@ class FlyerChatTextMessage extends StatelessWidget {
             ? TimeAndStatus(
               time: message.resolvedTime,
               status: message.resolvedStatus,
+              statusBuilder: statusBuilder,
               showTime: showTime,
+              timeBuilder: timeBuilder,
               showStatus: isSentByMe && showStatus,
               textStyle: timeStyle,
             )
@@ -266,7 +279,7 @@ class FlyerChatTextMessage extends StatelessWidget {
         theme.bodyMedium.copyWith(color: theme.onSurface);
   }
 
-  TextStyle? _resolveTimeStyle(bool isSentByMe, _LocalTheme theme) {
+  TextStyle _resolveTimeStyle(bool isSentByMe, _LocalTheme theme) {
     if (isSentByMe) {
       return timeStyle ??
           theme.labelSmall.copyWith(
@@ -292,41 +305,67 @@ class TimeAndStatus extends StatelessWidget {
   final bool showStatus;
 
   /// The text style for the time and status.
-  final TextStyle? textStyle;
+  final TextStyle textStyle;
+
+  /// Builder for the status widget if not provided, will build a default widget with Icons
+  final Widget Function(BuildContext context, MessageStatus? status)?
+  statusBuilder;
+
+  /// Builder for the time widget, if not provided will build a default widget using the HH:mm format
+  final Widget Function(BuildContext context, DateTime time)? timeBuilder;
 
   /// Creates a widget for displaying time and status.
   const TimeAndStatus({
     super.key,
     required this.time,
+    required this.textStyle,
     this.status,
     this.showTime = true,
     this.showStatus = true,
-    this.textStyle,
+    this.timeBuilder,
+    this.statusBuilder,
   });
 
   @override
   Widget build(BuildContext context) {
+    final timeWidgetBuilder = timeBuilder ?? _defaultTimeBuilder;
+    final statusWidgetBuilder = statusBuilder ?? _defaultStatusBuilder;
+
+    return IconTheme(
+      data: IconThemeData(color: textStyle.color, size: 12),
+      child: DefaultTextStyle(
+        style: textStyle,
+        child: Row(
+          spacing: 2,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showTime && time != null) timeWidgetBuilder(context, time!),
+            if (showStatus && status != null)
+              statusWidgetBuilder(context, status),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _defaultTimeBuilder(BuildContext context, DateTime time) {
     final timeFormat = context.watch<DateFormat>();
 
-    return Row(
-      spacing: 2,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (showTime && time != null)
-          Text(timeFormat.format(time!.toLocal()), style: textStyle),
-        if (showStatus && status != null)
-          if (status == MessageStatus.sending)
-            SizedBox(
-              width: 6,
-              height: 6,
-              child: CircularProgressIndicator(
-                color: textStyle?.color,
-                strokeWidth: 2,
-              ),
-            )
-          else
-            Icon(getIconForStatus(status!), color: textStyle?.color, size: 12),
-      ],
-    );
+    return Text(timeFormat.format(time.toLocal()));
+  }
+
+  Widget _defaultStatusBuilder(BuildContext context, MessageStatus? status) {
+    if (status == MessageStatus.sending) {
+      return SizedBox(
+        width: 6,
+        height: 6,
+        child: CircularProgressIndicator(
+          color: textStyle.color,
+          strokeWidth: 2,
+        ),
+      );
+    }
+
+    return Icon(getIconForStatus(status!));
   }
 }


### PR DESCRIPTION
Hello,

I'd like to add 2 new builders to the flyer_chat widgets to customize the status icons. The idea behind this is to be able to both change the icons of the message status and to show that a message has been edited next to the icon (like Whatsapp does)

## Summary

- Introduces statusBuilder and timeBuilder to all Flyer Chat message widgets.
- Enables full control over the UI and timestamp rendering without forking components.
- Maintains default behavior when builders aren’t provided.

## What’s Changed

- Adds optional statusBuilder to render custom delivery status.
- Adds optional timeBuilder to customize timestamp display using provided DateTime .

Here is a quick example on how to use it.

```dart
class CustomStatus extends StatelessWidget {
  const CustomStatus({super.key, this.status});

  final MessageStatus? status;

  @override
  Widget build(BuildContext context) {
    return Text('Custom');
  }
}

// ...

return Chat(
  builders: Builders(
    textMessageBuilder: (context, message, index, {required bool isSentByMe, MessageGroupStatus? groupStatus}) {
      return FlyerChatTextMessage(
        message: message,
        index: index,
        statusBuilder: (context, status) => CustomStatus(status: message.status),
      );
    },
  ),
);
```

<img width="588" height="1218" alt="Screenshot 2025-10-29 at 14 19 47" src="https://github.com/user-attachments/assets/9c8fe66e-d0a1-4a1b-9384-8079cbda808e" />

## Usage Notes

- Both builders are optional; defaults remain unchanged.
- timeBuilder receives the message time for custom formatting or localization.
## Backward Compatibility

- No breaking changes; existing UIs continue to render as before.
- Builder callbacks only override specific sections when provided.


I hope this isn't out of scope and could be added to this awesome package. Let me know if you need anything changed.