### PR TITLE
Dont scroll to bottom when a message is inserted.

### DIFF
--- a/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
@@ -565,6 +565,10 @@ class _ChatAnimatedListState extends State<ChatAnimatedList>
   }
 
   void _initialScrollToEnd() async {
+    if (widget.initialScrollToEndMode == InitialScrollToEndMode.none) {
+      return;
+    }
+    
     // Delay the scroll to the end animation so new message is painted, otherwise
     // maxScrollExtent is not yet updated and the animation might not work.
     await Future.delayed(widget.insertAnimationDuration);


### PR DESCRIPTION
Dont scroll to bottom when a message is inserted and the list becomes scrollable. (Resolves #885)

When the `ChatAnimatedList` transitions from non-scrollable to scrollable, for example, when a message that does not fit the viewport is received, it automatically scrolls to the end. As a result, the user needs to scroll up again to see the beginning of the message.

The sample code is provided in the issue.

https://github.com/user-attachments/assets/8c13c4d4-12c0-4b92-a5d7-2152a6bfb9f5

I'm not sure if this change might break some legit behavior.