### PR TITLE
feat: expose cacheExtent on ChatAnimatedList

### DIFF
--- a/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list.dart
@@ -121,6 +121,15 @@ class ChatAnimatedList extends StatefulWidget {
   /// Physics for the scroll view.
   final ScrollPhysics? physics;
 
+  /// Cache extent for the underlying [CustomScrollView].
+  ///
+  /// Widening this keeps off-screen messages measured by [SliverList], so
+  /// their exact heights stay in the scroll extent calculation instead of
+  /// being replaced by the running average of active children. This prevents
+  /// scrollbar thumb jumps when tall messages (e.g. long markdown or tables)
+  /// leave the viewport.
+  final double? cacheExtent;
+
   /// Creates an animated chat list.
   const ChatAnimatedList({
     super.key,
@@ -178,6 +187,7 @@ class ChatAnimatedList extends StatefulWidget {
     this.messagesGroupingMode,
     this.messageGroupingTimeoutInSeconds,
     this.physics,
+    this.cacheExtent,
   });
 
   @override
@@ -479,6 +489,7 @@ class _ChatAnimatedListState extends State<ChatAnimatedList>
               controller: _scrollController,
               reverse: widget.reversed,
               physics: widget.physics,
+              cacheExtent: widget.cacheExtent,
               keyboardDismissBehavior:
                   widget.keyboardDismissBehavior ??
                   ScrollViewKeyboardDismissBehavior.manual,

--- a/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list_reversed.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_animated_list/chat_animated_list_reversed.dart
@@ -77,6 +77,9 @@ class ChatAnimatedListReversed extends StatelessWidget {
   /// Physics for the scroll view.
   final ScrollPhysics? physics;
 
+  /// Cache extent for the underlying [CustomScrollView].
+  final double? cacheExtent;
+
   /// Creates a reversed animated chat list.
   const ChatAnimatedListReversed({
     super.key,
@@ -129,6 +132,7 @@ class ChatAnimatedListReversed extends StatelessWidget {
     this.messagesGroupingMode,
     this.messageGroupingTimeoutInSeconds,
     this.physics,
+    this.cacheExtent,
   });
 
   @override
@@ -159,6 +163,7 @@ class ChatAnimatedListReversed extends StatelessWidget {
       startPaginationThreshold: startPaginationThreshold,
       messageGroupingTimeoutInSeconds: messageGroupingTimeoutInSeconds,
       physics: physics,
+      cacheExtent: cacheExtent,
     );
   }
 }


### PR DESCRIPTION
Add an optional `cacheExtent` parameter on `ChatAnimatedList` (and `ChatAnimatedListReversed`) that is forwarded to the underlying `CustomScrollView`.

`SliverList` only tracks exact heights for items within the viewport plus the cache extent (default 250px). Once a tall message scrolls past that window, its measured height is discarded and the sliver falls back to estimating remaining extent from the running average of currently-active children. In chats with a mix of short and tall messages (e.g. long markdown or tables), this causes `maxScrollExtent` to shift whenever a big message enters or leaves the cache, which in turn makes the scrollbar thumb visibly jump during scrolling.

Exposing `cacheExtent` lets embedders widen the measured window so every message in a typical conversation stays accounted for, keeping `maxScrollExtent` stable. Defaults to `null` (framework default), so existing users are unaffected.

Caution. It is AI generate changes. But it looks very clear.